### PR TITLE
[Linux] Use Qt 6.4 for compatibility with Debian Stable

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,9 +4,9 @@ project(linux VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Quick Widgets Bluetooth DBus)
+find_package(Qt6 6.4 REQUIRED COMPONENTS Quick Widgets Bluetooth DBus)
 
-qt_standard_project_setup(REQUIRES 6.5)
+qt_standard_project_setup(REQUIRES 6.4)
 
 qt_add_executable(applinux
     main.cpp

--- a/linux/README.md
+++ b/linux/README.md
@@ -14,7 +14,13 @@ A native Linux application to control your AirPods, with support for:
 2. Qt6 packages
 
    ```bash
-   sudo pacman -S qt6-base qt6-connectivity qt6-multimedia-ffmpeg qt6-multimedia # Arch Linux / EndeavourOS
+   # For Arch Linux / EndeavourOS
+   sudo pacman -S qt6-base qt6-connectivity qt6-multimedia-ffmpeg qt6-multimedia
+
+   # For Debian
+   sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
+        qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
+        qml6-module-qtquick-window qml6-module-qtquick-layouts
    ```
 
 ## Setup

--- a/linux/ble/CMakeLists.txt
+++ b/linux/ble/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Core Bluetooth Widgets)
+find_package(Qt6 6.4 REQUIRED COMPONENTS Core Bluetooth Widgets)
 
 qt_add_executable(ble_monitor
     main.cpp

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -367,7 +367,7 @@ private slots:
         }
         else
         {
-            parent->loadFromModule("linux", "Main");
+            loadMainModule();
         }
     }
 
@@ -379,7 +379,7 @@ private slots:
         }
         else
         {
-            parent->loadFromModule("linux", "Main");
+            loadMainModule();
         }
     }
 
@@ -908,6 +908,10 @@ private slots:
         connectToPhone();
     }
 
+    void loadMainModule() {
+        parent->load(QUrl(QStringLiteral("qrc:/linux/Main.qml")));
+    }
+
 signals:
     void noiseControlModeChanged(NoiseControlMode mode);
     void earDetectionStatusChanged(const QString &status);
@@ -995,7 +999,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterType<Battery>("me.kavishdevar.Battery", 1, 0, "Battery");
     AirPodsTrayApp *trayApp = new AirPodsTrayApp(debugMode, hideOnStart, &engine);
     engine.rootContext()->setContextProperty("airPodsTrayApp", trayApp);
-    engine.loadFromModule("linux", "Main");
+    trayApp->loadMainModule();
 
     QLocalServer server;
     QLocalServer::removeServer("app_server");
@@ -1012,7 +1016,7 @@ int main(int argc, char *argv[]) {
     QObject::connect(&server, &QLocalServer::newConnection, [&]() {
         QLocalSocket* socket = server.nextPendingConnection();
         // Handles Proper Connection
-        QObject::connect(socket, &QLocalSocket::readyRead, [socket, &engine]() {
+        QObject::connect(socket, &QLocalSocket::readyRead, [socket, &engine, &trayApp]() {
             QString msg = socket->readAll();
             // Check if the message is "reopen", if so, trigger onOpenApp function
             if (msg == "reopen") {
@@ -1023,7 +1027,7 @@ int main(int argc, char *argv[]) {
                 }
                 else
                 {
-                    engine.loadFromModule("linux", "Main");
+                    trayApp->loadMainModule();
                 }
             }
             else


### PR DESCRIPTION
Hi! I hope there is no critical reason to require Qt 6.5 as the minimum version. Debian 12 still has Qt 6.4 in its repositories, so I patched this (absolutely great) app to work with it.

AFAICT, the only missing feature in Qt 6.4 was `QQmlApplicationEngine::loadFromModule`, which was introduced in 6.5. I replaced it with an older but equivalent approach to achieve the same functionality.

In the second commit, I updated the README and added an apt command with necessary Debian dependencies.

Tested on Debian 12 with Qt 6.4.2, everything works OK so far.