### PR TITLE
Fixes and improvements to the Linux readme

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -25,9 +25,19 @@ A native Linux application to control your AirPods, with support for:
     # For Fedora
     sudo dnf install qt6-qtbase-devel qt6-qtconnectivity-devel \
         qt6-qtmultimedia-devel qt6-qtdeclarative-devel
-
    ```
+3. OpenSSL development headers
 
+    ```bash
+    # On Arch Linux / EndevaourOS, these are included in the OpenSSL package, so you might already have them installed.
+    sudo pacman -S openssl
+    
+    # For Debian / Ubuntu
+    sudo apt-get install libssl-devel
+    
+    # For Fedora
+    sudo dnf install openssl-devel
+    ```
 ## Setup
 
 1. Edit `main.h` and update `PHONE_MAC_ADDRESS` with your phone's Bluetooth MAC address:

--- a/linux/README.md
+++ b/linux/README.md
@@ -21,6 +21,11 @@ A native Linux application to control your AirPods, with support for:
    sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
         qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
         qml6-module-qtquick-window qml6-module-qtquick-layouts
+
+    # For Fedora
+    sudo dnf install qt6-qtbase-devel qt6-qtconnectivity-devel \
+        qt6-qtmultimedia-devel qt6-qtdeclarative-devel
+
    ```
 
 ## Setup

--- a/linux/README.md
+++ b/linux/README.md
@@ -58,7 +58,7 @@ A native Linux application to control your AirPods, with support for:
 3. Run the application:
 
    ```bash
-   ./applinux
+   ./librepods
    ```
 
 ## Usage

--- a/linux/README.md
+++ b/linux/README.md
@@ -40,10 +40,10 @@ A native Linux application to control your AirPods, with support for:
     ```
 ## Setup
 
-1. Edit `main.h` and update `PHONE_MAC_ADDRESS` with your phone's Bluetooth MAC address:
+1. Set the `PHONE_MAC_ADDRESS` environment variable to your phone's Bluetooth MAC address by running the following:
 
-   ```cpp
-   #define PHONE_MAC_ADDRESS "XX:XX:XX:XX:XX:XX"  // Replace with your phone's MAC
+   ```bash
+   export PHONE_MAC_ADDRESS="XX:XX:XX:XX:XX:XX"  # Replace with your phone's MAC
    ```
 
 2. Build the application:


### PR DESCRIPTION
Hey!

While building Librepods, I've noticed some errors in the Linux readme, as well places for improvement. 

Changes:
* Added qt development header list for Fedora
* Added openssl development header dependency (this is bundled in the openssl package on Arch, but not in most other distros)
* `PHONE_MAC_ADDRESS` is no longer a build-time constant, but an environment variable
* The build target is `librepods`, not `applinux`

I've separated each change into a commit of it's own so you can easily cherry-pick the changes you want to apply if you don't want to set some.

Thank you for this project, hope this PR is welcome :smile: 