### PR TITLE
Fixed build instructions for ubuntu

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -33,7 +33,7 @@ A native Linux application to control your AirPods, with support for:
     sudo pacman -S openssl
     
     # For Debian / Ubuntu
-    sudo apt-get install libssl-devel
+    sudo apt-get install libssl-dev
     
     # For Fedora
     sudo dnf install openssl-devel


### PR DESCRIPTION
This pull request includes a small correction to the `linux/README.md` file. The change fixes the package name for Debian/Ubuntu from `libssl-devel` to `libssl-dev` to ensure proper installation instructions as libssl-devel does not exist.