### PR TITLE
fix: update rename function call for airPods

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -265,7 +265,7 @@ ApplicationWindow {
 
                         Button {
                             text: "Rename"
-                            onClicked: airPodsTrayApp.deviceInfo.renameAirPods(newNameField.text)
+                            onClicked: airPodsTrayApp.renameAirPods(newNameField.text)
                         }
                     }
 


### PR DESCRIPTION
Previously, it was failing with an error stating that 'renameAirPods' is not a function.
This PR should fix that, as the function is defined in airPodsTrayApp.

I've tested this change on my Ubuntu machine and AirPods Pro 2

Thank you for this awesome project!