### PR TITLE
[Linux] chore: change logging name airpodsApp -> Librepods

### DIFF
--- a/linux/logger.h
+++ b/linux/logger.h
@@ -3,9 +3,9 @@
 #include <QDebug>
 #include <QLoggingCategory>
 
-Q_DECLARE_LOGGING_CATEGORY(airpodsApp)
+Q_DECLARE_LOGGING_CATEGORY(Librepods)
 
-#define LOG_INFO(msg) qCInfo(airpodsApp) << "\033[32m" << msg << "\033[0m"
-#define LOG_WARN(msg) qCWarning(airpodsApp) << "\033[33m" << msg << "\033[0m"
-#define LOG_ERROR(msg) qCCritical(airpodsApp) << "\033[31m" << msg << "\033[0m"
-#define LOG_DEBUG(msg) qCDebug(airpodsApp) << "\033[34m" << msg << "\033[0m"
+#define LOG_INFO(msg) qCInfo(Librepods) << "\033[32m" << msg << "\033[0m"
+#define LOG_WARN(msg) qCWarning(Librepods) << "\033[33m" << msg << "\033[0m"
+#define LOG_ERROR(msg) qCCritical(Librepods) << "\033[31m" << msg << "\033[0m"
+#define LOG_DEBUG(msg) qCDebug(Librepods) << "\033[34m" << msg << "\033[0m"

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -28,7 +28,7 @@
 
 using namespace AirpodsTrayApp::Enums;
 
-Q_LOGGING_CATEGORY(airpodsApp, "airpodsApp")
+Q_LOGGING_CATEGORY(Librepods, "Librepods")
 
 class AirPodsTrayApp : public QObject {
     Q_OBJECT
@@ -48,7 +48,7 @@ public:
         , m_deviceInfo(new DeviceInfo(this)), m_bleManager(new BleManager(this))
         , m_systemSleepMonitor(new SystemSleepMonitor(this))
     {
-        QLoggingCategory::setFilterRules(QString("airpodsApp.debug=%1").arg(debugMode ? "true" : "false"));
+        QLoggingCategory::setFilterRules(QString("Librepods.debug=%1").arg(debugMode ? "true" : "false"));
         LOG_INFO("Initializing AirPodsTrayApp");
 
         // Initialize tray icon and connect signals


### PR DESCRIPTION
**old:**
```
airpodsApp:  Primary Pod: Battery::Component::Left 
airpodsApp:  Secondary Pod: Battery::Component::Right 
airpodsApp:  Battery status:  "Left: 87%, Right: 88%, Case: 0%" 
````

**new:**
```
Librepods:  Primary Pod: Battery::Component::Left 
Librepods:  Secondary Pod: Battery::Component::Right 
Librepods:  Battery status:  "Left: 87%, Right: 88%, Case: 0%" 
````