### PR TITLE
[Linux] Let users edit Phone bluetooth MAC via GUI

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -154,7 +154,27 @@ ApplicationWindow {
                     visible: airPodsTrayApp.airpodsConnected
                     text: "Conversational Awareness"
                     checked: airPodsTrayApp.deviceInfo.conversationalAwareness
+                    // Disable when no phone MAC set or using default placeholder
+                    enabled: !(PHONE_MAC_ADDRESS === "" || PHONE_MAC_ADDRESS === "00:00:00:00:00:00")
                     onCheckedChanged: airPodsTrayApp.setConversationalAwareness(checked)
+                }
+
+                // Instruction when Conversational Awareness is disabled due to missing phone MAC
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: 8
+                    visible: airPodsTrayApp.airpodsConnected && (PHONE_MAC_ADDRESS === "" || PHONE_MAC_ADDRESS === "00:00:00:00:00:00")
+
+                    Label {
+                        text: "Set your phone's MAC in Settings to use this feature"
+                        font.pixelSize: 12
+                        color: "gray"
+                    }
+
+                    Button {
+                        text: "Open Settings"
+                        onClicked: stackView.push(settingsPage)
+                    }
                 }
             }
 
@@ -268,6 +288,23 @@ ApplicationWindow {
                             onClicked: airPodsTrayApp.renameAirPods(newNameField.text)
                         }
                     }
+
+                    Row {
+                        spacing: 10
+                        visible: airPodsTrayApp.airpodsConnected
+
+                        TextField {
+                            id: newPhoneMacField
+                            placeholderText: (PHONE_MAC_ADDRESS !== "" ? PHONE_MAC_ADDRESS : "00:00:00:00:00:00")
+                            maximumLength: 32
+                        }
+
+                        Button {
+                            text: "Change Phone MAC"
+                            onClicked: airPodsTrayApp.setPhoneMac(newPhoneMacField.text)
+                        }
+                    }
+
 
                     Button {
                         text: "Show Magic Cloud Keys QR"


### PR DESCRIPTION
<img width="1170" height="848" alt="Screenshot_20250825_173412" src="https://github.com/user-attachments/assets/6a84eb59-e1d4-4dcc-9057-52cd92729c1e" />
When the environment variable "PHONE_MAC_ADDRESS" is not set:

<br/><br/><br/>
<img width="1172" height="850" alt="Screenshot_20250825_173420" src="https://github.com/user-attachments/assets/79b98882-d980-4149-8043-1de48b56ea5d" />
Default mac:

<br/><br/><br/>
<img width="1402" height="1031" alt="Screenshot_20250825_173356" src="https://github.com/user-attachments/assets/f6b74003-6f4b-42fa-ac98-75292c6c4e7a" />
When mac is set (still editable):