### PR TITLE
[Linux] Resolve connected phone 

### DIFF
--- a/linux/BluetoothMonitor.h
+++ b/linux/BluetoothMonitor.h
@@ -28,7 +28,14 @@ private:
     QDBusConnection m_dbus;
     void registerDBusService();
     bool isAirPodsDevice(const QString &devicePath);
-    QString getDeviceName(const QString &devicePath);
+    QString getDevicePath(const QString &macAddress);
+    QString getDeviceNameFromBluetooth(const QString &macAddress);
+    QString getDeviceNameFromBluetoothctl(const QString &macAddress);
+    QString getDeviceNameFromCache(const QString &macAddress);
+    QStringList findAdapters();
+
+public:
+    QString getDeviceName(const QString &macAddress);
 };
 
 #endif // BLUETOOTHMONITOR_H

--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -152,7 +152,7 @@ ApplicationWindow {
 
                 Switch {
                     visible: airPodsTrayApp.airpodsConnected
-                    text: "Conversational Awareness"
+                    text: "Conversational Awareness" + (airPodsTrayApp.connectedPhoneName ? " (" + airPodsTrayApp.connectedPhoneName + ")" : "")
                     checked: airPodsTrayApp.deviceInfo.conversationalAwareness
                     // Disable when no phone MAC set or using default placeholder
                     enabled: !(PHONE_MAC_ADDRESS === "" || PHONE_MAC_ADDRESS === "00:00:00:00:00:00")

--- a/linux/trayiconmanager.cpp
+++ b/linux/trayiconmanager.cpp
@@ -54,6 +54,17 @@ void TrayIconManager::updateConversationalAwareness(bool enabled)
     caToggleAction->setChecked(enabled);
 }
 
+void TrayIconManager::setPhoneName(const QString &name)
+{
+    m_phoneName = name;
+    // Update the action text to include the phone name when available
+    if (m_phoneName.isEmpty()) {
+        caToggleAction->setText("Toggle Conversational Awareness");
+    } else {
+        caToggleAction->setText(QString("Toggle Conversational Awareness — %1").arg(m_phoneName));
+    }
+}
+
 void TrayIconManager::setupMenuActions()
 {
     // Open action

--- a/linux/trayiconmanager.h
+++ b/linux/trayiconmanager.h
@@ -33,6 +33,9 @@ public:
         }
     }
 
+    // Set or clear the resolved phone name displayed next to the Conversational Awareness menu entry
+    void setPhoneName(const QString &name);
+
     void resetTrayIcon()
     {
         trayIcon->setIcon(QIcon(":/icons/assets/airpods.png"));
@@ -51,6 +54,7 @@ private:
     QAction *caToggleAction;
     QActionGroup *noiseControlGroup;
     bool m_notificationsEnabled = true;
+    QString m_phoneName;
 
     void setupMenuActions();
 


### PR DESCRIPTION
<img width="1253" height="949" alt="image" src="https://github.com/user-attachments/assets/58160b7b-6423-40d9-b752-446d84a79ac8" />
quite a lot of code for the name of the connected phone.
the lookup of the name is in cache, and bluetooth-resolving


i would totally get it if you guys think this is over-engineered