### PR TITLE
[Linux] Several fixes for conversational awareness

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -291,7 +291,6 @@ ApplicationWindow {
 
                     Row {
                         spacing: 10
-                        visible: airPodsTrayApp.airpodsConnected
 
                         TextField {
                             id: newPhoneMacField


### PR DESCRIPTION
fix1: let users change the phone mac-address eventhough the airpods are not connected
fix2: previously the environment variable was set with the `export` command which was not persistent after a reboot. now the phone mac is stored in ~/.profile which is persistent