### PR TITLE
linux: add desktop entry file

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -75,3 +75,5 @@ install(TARGETS librepods
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+install(FILES assets/me.kavishdevar.librepods.desktop
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")

--- a/linux/assets/me.kavishdevar.librepods.desktop
+++ b/linux/assets/me.kavishdevar.librepods.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=LibrePods
+Comment=AirPods libreated from Apple's ecosystem
+Exec=librepods
+Icon=librepods
+Terminal=false
+Categories=Audio;AudioVideo;Utility;Qt;

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -951,6 +951,7 @@ int main(int argc, char *argv[]) {
             LOG_DEBUG("Socket error: " << socket.errorString());
         }
     }
+    app.setDesktopFileName("me.kavishdevar.librepods");
     app.setQuitOnLastWindowClosed(false);
 
     bool debugMode = false;


### PR DESCRIPTION
According to [Freedesktop Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/file-naming.html), the name of the desktop entry should follow the "reverse DNS" convention.