### PR TITLE
Fix: Activate A2DP audio profile for AirPods after system reboot on Linx

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -96,6 +96,15 @@ public:
             QBluetoothDeviceInfo device(address, "", 0);
             if (isAirPodsDevice(device)) {
                 connectToDevice(device);
+
+                // On startup after reboot, activate A2DP profile for already connected AirPods
+                QTimer::singleShot(2000, this, [this, address]()
+                {
+                    QString formattedAddress = address.toString().replace(":", "_");
+                    mediaController->setConnectedDeviceMacAddress(formattedAddress);
+                    mediaController->activateA2dpProfile();
+                    LOG_INFO("A2DP profile activation attempted for AirPods found on startup");
+                });
                 return;
             }
         }
@@ -397,6 +406,23 @@ public slots:
     {
         LOG_INFO("System is waking up, starting ble scan");
         m_bleManager->startScan();
+
+        // Check if AirPods are already connected and activate A2DP profile
+        if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
+        {
+            LOG_INFO("AirPods already connected after wake-up, re-activating A2DP profile");
+            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
+
+            // Always activate A2DP profile after system wake since the profile might have been lost
+            QTimer::singleShot(1000, this, [this]()
+            {
+                mediaController->activateA2dpProfile();
+                LOG_INFO("A2DP profile activation attempted after system wake-up");
+            });
+        }
+
+        // Also check for already connected devices via BlueZ
+        monitor->checkAlreadyConnectedDevices();
     }
 
 private slots:
@@ -445,6 +471,20 @@ private slots:
     {
         QBluetoothDeviceInfo device(QBluetoothAddress(address), name, 0);
         connectToDevice(device);
+
+        // After system reboot, AirPods might be connected but A2DP profile not active
+        // Attempt to activate A2DP profile after a delay to ensure connection is established
+        QTimer::singleShot(2000, this, [this, address]()
+        {
+            if (!address.isEmpty())
+            {
+                QString formattedAddress = address;
+                formattedAddress = formattedAddress.replace(":", "_");
+                mediaController->setConnectedDeviceMacAddress(formattedAddress);
+                mediaController->activateA2dpProfile();
+                LOG_INFO("A2DP profile activation attempted for newly connected device");
+            }
+        });
     }
 
     void onDeviceDisconnected(const QBluetoothAddress &address)


### PR DESCRIPTION
After a system reboot, **AirPods microphone** is detected, but the **audio output (A2DP sink) is not available**. This occurs because the Bluetooth connection is automatically restored by the system, but the **A2DP audio profile** is not activated, leaving only the **HFP/HSP profile** active (microphone only).

---

### Solution

The solution is to add **A2DP profile activation** in three key scenarios:

1.  **On system wake-up**: Checks if AirPods are already connected and re-activates the A2DP profile.
2.  **On BlueZ device connection**: Activates the A2DP profile when AirPods are detected as connected via **BlueZ** (happens after reboot).
3.  **On app startup**: Activates the A2DP profile for already connected AirPods found during initialization.

---

### Test Scenario

| Category | Detail |
| :--- | :--- |
| **Platform** | Linux (OpenSUSE Tumbleweed, kernel 6.16.8-1-default) |
| **Device** | AirPods Pro 3 |
| **Audio System** | PulseAudio (`pactl`) |
| **Test Scenarios** | - System reboot with AirPods already paired<br>- Wake from sleep/suspend<br>- App restart while AirPods connected<br>- ✅ Manual Bluetooth reconnection |

---

### Technical Details

The fix ensures that `pactl set-card-profile [device] a2dp-sink` is called after detecting the AirPods connection, with appropriate delays **(1-2 seconds)** to ensure the Bluetooth connection is fully established before attempting profile switching.

This addresses the issue where users had to manually select AirPods as the audio output device / audio device not poping up after every reboot.