### PR TITLE
Auto-restart WirePlumber when A2DP profile is unavailable

### DIFF
--- a/linux/media/mediacontroller.h
+++ b/linux/media/mediacontroller.h
@@ -37,6 +37,8 @@ public:
   void activateA2dpProfile();
   void removeAudioOutputDevice();
   void setConnectedDeviceMacAddress(const QString &macAddress);
+  bool isA2dpProfileAvailable();
+  bool restartWirePlumber();
 
   void setEarDetectionBehavior(EarDetectionBehavior behavior);
   inline EarDetectionBehavior getEarDetectionBehavior() const { return earDetectionBehavior; }


### PR DESCRIPTION
This PR improves upon the earlier fix in PR #212, which handled A2DP activation timing but didn't address cases where the profile was completely unavailable due to WirePlumber's discovery timing issues. Also might fix #205.

After a **system reboot** or **Bluetooth service restart**, WirePlumber (PipeWire's session manager) often fails to properly discover **A2DP** (Advanced Audio Distribution Profile) audio profiles for Bluetooth devices like **AirPods**.


### Symptoms:
- Only **HSP/HFP** (Headset/Hands-Free Profile) appears in available profiles
- A2DP profile is completely missing from the device card (not just inactive)
- Because of caching of the A2DP profile i needed to initially select **HSP/HFP** to get the audio source again
- Manual restart of WirePlumberis required to fix

### Root Cause:
This is probably a **timing issue** where WirePlumber queries the Bluetooth device too early during boot/reconnection, before the device has fully advertised its A2DP capabilities. WirePlumber then caches this incomplete profile list and doesn't automatically re-scan.

---

## Solution

Automatically **detect missing A2DP profiles** and restart WirePlumber to force profile rediscovery, then activate the A2DP profile.

---

## Changes Implemented

### New Functions:
- **`isA2dpProfileAvailable()`** - Checks if A2DP profile exists in `pactl list cards` output for the connected device
- **`restartWirePlumber()`** - Safely restarts the WirePlumber service via `systemctl --user restart wireplumber` and waits for rediscovery

### Modified Function:
- **`activateA2dpProfile()`** - Now includes automatic recovery:
  1. Check if A2DP profile is available
  2. If missing → restart WirePlumber
  3. Update device info after restart
  4. Verify A2DP is now available
  5. Activate A2DP profile

This approach **eliminates the need for manual WirePlumber restarts** or device reconnections after reboot.

---

## Testing Environment

| Category | Detail |
|:---------|:-------|
| **Platform** | OpenSUSE Tumbleweed (kernel 6.16.8) |
| **Audio System** | PipeWire + WirePlumber |
| **Test Device** | AirPods Pro 3 |
| **Tested Scenarios** | ✅ System reboot<br>✅ Wake from sleep/suspend<br>✅ Manual Bluetooth reconnection<br>✅ App restart while connected |

---

## Technical Notes

- Uses user-level systemctl to restart WirePlumber (no root permissions required)
- Includes 2-second wait after restart for proper profile rediscovery
- Only restarts WirePlumber when necessary (A2DP missing), not on every connection
- We might need support for PulseAudio
- We maybe should detect which audio system is running and only restart WirePlumber if it's available