### PR TITLE
Add bluetooth library for Google Pixel

### DIFF
--- a/root-module/customize.sh
+++ b/root-module/customize.sh
@@ -85,6 +85,7 @@ fi
 
 for lib_path in \
     "/apex/com.android.btservices/lib64/libbluetooth_jni.so" \
+    "/apex/com.android.bt/lib64/libbluetooth_jni.so" \
     "/system/lib64/libbluetooth_jni.so" \
     "/system/lib64/libbluetooth_qti.so" \
     "/system_ext/lib64/libbluetooth_qti.so"; do


### PR DESCRIPTION
Error:
```
- Copying zip to temp directory
- Installing btl2capfix (3).zip
- Current boot slot: _a
- Device is system-as-root
Archive:  /data/user/0/on.nv/cache/flash/install.zip
  inflating: module.prop
****************************************
 Bluetooth L2CAP workaround for AirPods 
 by @devnoname120 and @kavishdevar 
****************************************
*******************
 Powered by Magisk 
*******************
Archive:  /data/user/0/on.nv/cache/flash/install.zip
  inflating: customize.sh
- Extracting module files
Archive:  /data/user/0/on.nv/cache/flash/install.zip
   creating: busybox/
  inflating: busybox/xz
  inflating: busybox/busybox-arm64
  inflating: module.prop
  inflating: customize.sh
  inflating: radare2-5.9.9-android-aarch64-aln.tar.gz
[O] Extracting module files...
[O] Extracting radare2 to /data/local/tmp/aln_unzip...
[O] rabin2 binary is ready.
[O] radare2 binary is ready.
[O] busybox binary is ready.
[O] xz shim is ready.
[O] Error: No target library found.
[O] No target library found.
! Installation failed
```

The available bluetooth libraries on my Google Pixel 8 Pro:
```
husky:/ # find /system -name "*bluetooth*.so" 2>/dev/null                                                                                                                                                                                   
husky:/ # find /apex -name "*bluetooth*.so" 2>/dev/null                                                                                                                                                                                     
/apex/com.android.bt/lib64/libbluetooth_jni.so
/apex/com.android.bt@360832420/lib64/libbluetooth_jni.so
```
