### PR TITLE
linux: add support for multiple media players

### DIFF
--- a/linux/media/mediacontroller.h
+++ b/linux/media/mediacontroller.h
@@ -55,9 +55,9 @@ Q_SIGNALS:
 private:
   MediaState mediaStateFromPlayerctlOutput(const QString &output) const;
   QString getAudioDeviceName();
-  bool sendMediaPlayerCommand(const QString &method);
+  QStringList getPlayingMediaPlayers();
 
-  bool wasPausedByApp = false;
+  QStringList pausedByAppServices;
   int initialVolume = -1;
   QString connectedDeviceMacAddress;
   EarDetectionBehavior earDetectionBehavior = PauseWhenOneRemoved;


### PR DESCRIPTION
fixes #207 

note: this only works if the browser shows two instances for multiple media sources. playing two youtube videos in two separate tabs in Firefox exposed only one instance of media player which will not result in all media sources paused. Something I can't fix. But now, it will only resume the services it has paused not just the first one.