### PR TITLE
android: Add missing HEAD_GESTURES capability to the Airpods Pro 3

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/AirPods.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/AirPods.kt
@@ -187,6 +187,7 @@ class AirPodsPro3: AirPodsBase(
     capabilities = setOf(
         Capability.LISTENING_MODE,
         Capability.CONVERSATION_AWARENESS,
+        Capability.HEAD_GESTURES,
         Capability.STEM_CONFIG,
         Capability.LOUD_SOUND_REDUCTION,
         Capability.PPE,


### PR DESCRIPTION
I assume this was a regression, since in the prerelease build of 0.2.0 head tracking worked just fine :) 