### PR TITLE
docs(linux): use Github warning text for warning note

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -82,7 +82,8 @@ Then restart WirePlumber:
 systemctl --user restart wireplumber
 ```
 
-**Note:** Do NOT run `mpris-proxy` with WirePlumber - it will conflict and break media controls.
+> [!WARNING]
+> Do NOT run `mpris-proxy` with WirePlumber - it will conflict and break media controls.
 
 #### PulseAudio
 


### PR DESCRIPTION
[EDIT] didn't change the last line, but it looks like editing on GitHub Web automatically removed a trailing newline.