### PR TITLE
Add Airpods Max to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ LibrePods unlocks Apple's exclusive AirPods features on non-Apple devices. Get a
 | ------ | --------------------- | ---------------------------------------------------------- |
 | ✅      | AirPods Pro (2nd Gen) | Fully supported and tested                                 |
 | ✅      | AirPods Pro (3rd Gen) | Fully supported (except heartrate monitoring)              |
+| ✅      | AirPods Max           | Fully supported (client shows unsupported features)        |
 | ⚠️      | Other AirPods models  | Basic features (battery status, ear detection) should work |
 
 Most features should work with any AirPods. Currently, I've only got AirPods Pro 2 to test with.


### PR DESCRIPTION
Can confirm that this works perfectly on Linux with my pair of Airpods Max. The client does show features that are unsupported, like Adaptive mode, but all the functionality that works on my iPhone works on Linux.

Feel free to throw out this PR and still add it to the readme, or edit it. I don't care. I just felt like a PR would be much more useful than an issue.