### PR TITLE
refactor: remove unused textColor property and related preferences

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/MainActivity.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/MainActivity.kt
@@ -156,10 +156,6 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             LibrePodsTheme {
-                getSharedPreferences("settings", MODE_PRIVATE).edit {
-                    putLong(
-                        "textColor",
-                        MaterialTheme.colorScheme.onSurface.toArgb().toLong())}
                 Main()
             }
         }

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -167,7 +167,6 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         var headGestures: Boolean = true,
         var disconnectWhenNotWearing: Boolean = false,
         var conversationalAwarenessVolume: Int = 43,
-        var textColor: Long = -1L,
         var qsClickBehavior: String = "cycle",
         var bleOnlyMode: Boolean = false,
 
@@ -452,8 +451,6 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                     "conversational_awareness_volume",
                     43
                 )
-
-                if (!contains("textColor")) putLong("textColor", -1L)
 
                 if (!contains("qs_click_behavior")) putString("qs_click_behavior", "cycle")
                 if (!contains("name")) putString("name", "AirPods")
@@ -1203,7 +1200,6 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             headGestures = sharedPreferences.getBoolean("head_gestures", true),
             disconnectWhenNotWearing = sharedPreferences.getBoolean("disconnect_when_not_wearing", false),
             conversationalAwarenessVolume = sharedPreferences.getInt("conversational_awareness_volume", 43),
-            textColor = sharedPreferences.getLong("textColor", -1L),
             qsClickBehavior = sharedPreferences.getString("qs_click_behavior", "cycle") ?: "cycle",
 
             // AirPods state-based takeover
@@ -1262,7 +1258,6 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             "head_gestures" -> config.headGestures = preferences.getBoolean(key, true)
             "disconnect_when_not_wearing" -> config.disconnectWhenNotWearing = preferences.getBoolean(key, false)
             "conversational_awareness_volume" -> config.conversationalAwarenessVolume = preferences.getInt(key, 43)
-            "textColor" -> config.textColor = preferences.getLong(key, -1L)
             "qs_click_behavior" -> config.qsClickBehavior = preferences.getString(key, "cycle") ?: "cycle"
 
             // AirPods state-based takeover


### PR DESCRIPTION
Calling `getSharedPreferences` (non composable code) from a composable context is undefined behavior and should never be done.

The setting was never used anyway, so it's better to remove it directly.

More info at: https://developer.android.com/develop/ui/compose/side-effects