### PR TITLE
linux: AirPods Max battery status support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,5 @@ indent_size = 4
 trim_trailing_whitespace = false
 max_line_length = off
 
-[*.{py,java,r,R,kt,xml,kts}]
+[*.{py,java,r,R,kt,xml,kts,h,hpp,cpp,qml}]
 indent_size = 4

--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -118,6 +118,14 @@ ApplicationWindow {
                         batteryLevel: airPodsTrayApp.deviceInfo.battery.caseLevel
                         isCharging: airPodsTrayApp.deviceInfo.battery.caseCharging
                     }
+
+                    PodColumn {
+                        visible: airPodsTrayApp.deviceInfo.battery.headsetAvailable
+                        inEar: true
+                        iconSource: "qrc:/icons/assets/" + airPodsTrayApp.deviceInfo.podIcon
+                        batteryLevel: airPodsTrayApp.deviceInfo.battery.headsetLevel
+                        isCharging: airPodsTrayApp.deviceInfo.battery.headsetCharging
+                    }
                 }
 
                 SegmentedControl {

--- a/linux/airpods_packets.h
+++ b/linux/airpods_packets.h
@@ -113,24 +113,24 @@ namespace AirPodsPackets
         static const QByteArray HEADER = ControlCommand::HEADER + static_cast<char>(0x2C);
         static const QByteArray ENABLED = ControlCommand::createCommand(0x2C, 0x01, 0x01);
         static const QByteArray DISABLED = ControlCommand::createCommand(0x2C, 0x02, 0x02);
-        
+
         inline std::optional<bool> parseState(const QByteArray &data)
         {
             if (!data.startsWith(HEADER) || data.size() < HEADER.size() + 2)
                 return std::nullopt;
-            
+
             QByteArray value = data.mid(HEADER.size(), 2);
             if (value.size() != 2)
                 return std::nullopt;
-            
+
             char b1 = value.at(0);
             char b2 = value.at(1);
-            
+
             if (b1 == 0x01 && b2 == 0x01)
                 return true;
             if (b1 == 0x02 || b2 == 0x02)
                 return false;
-            
+
             return std::nullopt;
         }
     }

--- a/linux/deviceinfo.hpp
+++ b/linux/deviceinfo.hpp
@@ -197,7 +197,12 @@ public:
         int leftLevel = getBattery()->getState(Battery::Component::Left).level;
         int rightLevel = getBattery()->getState(Battery::Component::Right).level;
         int caseLevel = getBattery()->getState(Battery::Component::Case).level;
-        setBatteryStatus(QString("Left: %1%, Right: %2%, Case: %3%").arg(leftLevel).arg(rightLevel).arg(caseLevel));
+        if (getBattery()->getPrimaryPod() == Battery::Component::Headset) {
+            int headsetLevel = getBattery()->getState(Battery::Component::Headset).level;
+            setBatteryStatus(QString("Headset: %1%").arg(headsetLevel));
+        } else {
+            setBatteryStatus(QString("Left: %1%, Right: %2%, Case: %3%").arg(leftLevel).arg(rightLevel).arg(caseLevel));
+        }
     }
 
 signals:

--- a/linux/enums.h
+++ b/linux/enums.h
@@ -85,9 +85,21 @@ namespace AirpodsTrayApp
                     return {"podpro.png", "podpro_case.png"};
                 case AirPodsModel::AirPodsMaxLightning:
                 case AirPodsModel::AirPodsMaxUSBC:
-                    return {"max.png", "max_case.png"};
+                    return {"podmax.png", "max_case.png"};
                 default:
                     return {"pod.png", "pod_case.png"}; // Default icon for unknown models
+            }
+        }
+
+        // TODO: Only used for parseEncryptedPacket for battery status. Is it possible to determine this
+        // from the data in the packet rather than by model? i.e number of batteries
+        inline bool isModelHeadset(AirPodsModel model) {
+            switch (model) {
+                case AirPodsModel::AirPodsMaxLightning:
+                case AirPodsModel::AirPodsMaxUSBC:
+                    return true;
+                default:
+                    return false;
             }
         }
 

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -666,7 +666,7 @@ private slots:
         else if (data.startsWith(AirPodsPackets::Parse::FEATURES_ACK))
         {
             writePacketToSocket(AirPodsPackets::Connection::REQUEST_NOTIFICATIONS, "Request notifications packet written: ");
-            
+
             QTimer::singleShot(2000, this, [this]() {
                 if (m_deviceInfo->batteryStatus().isEmpty()) {
                     writePacketToSocket(AirPodsPackets::Connection::REQUEST_NOTIFICATIONS, "Request notifications packet written: ");
@@ -718,7 +718,7 @@ private slots:
             mediaController->handleEarDetection(m_deviceInfo->getEarDetection());
         }
         // Battery Status
-        else if (data.size() == 22 && data.startsWith(AirPodsPackets::Parse::BATTERY_STATUS))
+        else if ((data.size() == 22 || data.size() == 12) && data.startsWith(AirPodsPackets::Parse::BATTERY_STATUS))
         {
             m_deviceInfo->getBattery()->parsePacket(data);
             m_deviceInfo->updateBatteryStatus();
@@ -766,7 +766,7 @@ private slots:
         }
         QBluetoothAddress phoneAddress("00:00:00:00:00:00"); // Default address, will be overwritten if PHONE_MAC_ADDRESS is set
         QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-        
+
         if (!env.value("PHONE_MAC_ADDRESS").isEmpty())
         {
             phoneAddress = QBluetoothAddress(env.value("PHONE_MAC_ADDRESS"));
@@ -875,7 +875,7 @@ private slots:
         if (BLEUtils::isValidIrkRpa(m_deviceInfo->magicAccIRK(), device.address)) {
             m_deviceInfo->setModel(device.modelName);
             auto decryptet = BLEUtils::decryptLastBytes(device.encryptedPayload, m_deviceInfo->magicAccEncKey());
-            m_deviceInfo->getBattery()->parseEncryptedPacket(decryptet, device.primaryLeft, device.isThisPodInTheCase);
+            m_deviceInfo->getBattery()->parseEncryptedPacket(decryptet, device.primaryLeft, device.isThisPodInTheCase, isModelHeadset(m_deviceInfo->model()));
             m_deviceInfo->getEarDetection()->overrideEarDetectionStatus(device.isPrimaryInEar, device.isSecondaryInEar);
         }
     }
@@ -991,7 +991,7 @@ int main(int argc, char *argv[]) {
     sharedMemory.setKey("TcpServer-Key2");
 
     // Check if app is already open
-    if(sharedMemory.create(1) == false) 
+    if(sharedMemory.create(1) == false)
     {
         LOG_INFO("Another instance already running! Opening App Window Instead");
         QLocalSocket socket;
@@ -1083,7 +1083,7 @@ int main(int argc, char *argv[]) {
             LOG_ERROR("Failed to connect to the duplicate app instance");
             LOG_DEBUG("Connection error: " << socket->errorString());
         });
-        
+
         // Handle server-level errors
         QObject::connect(&server, &QLocalServer::serverError, [&]() {
             LOG_ERROR("Server failed to accept a new connection");

--- a/linux/trayiconmanager.cpp
+++ b/linux/trayiconmanager.cpp
@@ -109,20 +109,21 @@ void TrayIconManager::updateIconFromBattery(const QString &status)
 {
     int leftLevel = 0;
     int rightLevel = 0;
+    int minLevel = 0;
 
     if (!status.isEmpty())
     {
         // Parse the battery status string
         QStringList parts = status.split(", ");
-        if (parts.size() >= 2)
-        {
+        if (parts.size() >= 2) {
             leftLevel = parts[0].split(": ")[1].replace("%", "").toInt();
             rightLevel = parts[1].split(": ")[1].replace("%", "").toInt();
+            minLevel = (leftLevel == 0) ? rightLevel : (rightLevel == 0) ? leftLevel
+                                                                    : qMin(leftLevel, rightLevel);
+        } else if (parts.size() == 1) {
+            minLevel = parts[0].split(": ")[1].replace("%", "").toInt();
         }
     }
-    
-    int minLevel = (leftLevel == 0) ? rightLevel : (rightLevel == 0) ? leftLevel
-                                                                     : qMin(leftLevel, rightLevel);
 
     QPixmap pixmap(32, 32);
     pixmap.fill(Qt::transparent);


### PR DESCRIPTION
Fixes various bugs with AirPods Max support in the _legacy_ (not Rust) version of the Linux app:

- Headset icon now appears properly in main application window
- Battery status now reported correctly in tray icon and on hover and in logs
- Bogus L/R/Case batteries no longer reported in main application window
- Supports the smaller battery update packets (size 12) which should make the battery status actually update as the device drains now

<img width="454" height="327" alt="Screenshot_20251119_134356" src="https://github.com/user-attachments/assets/9f6f2cdd-7643-405c-9a67-df3335875759" />

