### PR TITLE
android(fix): parse and send hearing aid data properly

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/screens/HearingAidAdjustmentsScreen.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/screens/HearingAidAdjustmentsScreen.kt
@@ -96,12 +96,9 @@ fun HearingAidAdjustmentsScreen(@Suppress("unused") navController: NavController
             val toneSliderValue = remember { mutableFloatStateOf(0.5f) }
             val ambientNoiseReductionSliderValue = remember { mutableFloatStateOf(0.0f) }
             val conversationBoostEnabled = remember { mutableStateOf(false) }
-            val eq = remember { mutableStateOf(FloatArray(8)) }
+            val leftEQ = remember { mutableStateOf(FloatArray(8)) }
+            val rightEQ = remember { mutableStateOf(FloatArray(8)) }
             val ownVoiceAmplification = remember { mutableFloatStateOf(0.5f) }
-
-            val phoneMediaEQ = remember { mutableStateOf(FloatArray(8) { 0.5f }) }
-            val phoneEQEnabled = remember { mutableStateOf(false) }
-            val mediaEQEnabled = remember { mutableStateOf(false) }
 
             val initialLoadComplete = remember { mutableStateOf(false) }
 
@@ -111,8 +108,8 @@ fun HearingAidAdjustmentsScreen(@Suppress("unused") navController: NavController
             val hearingAidSettings = remember {
                 mutableStateOf(
                     HearingAidSettings(
-                        leftEQ = eq.value,
-                        rightEQ = eq.value,
+                        leftEQ = leftEQ.value,
+                        rightEQ = rightEQ.value,
                         leftAmplification = amplificationSliderValue.floatValue + (0.5f - balanceSliderValue.floatValue) * amplificationSliderValue.floatValue * 2,
                         rightAmplification = amplificationSliderValue.floatValue + (balanceSliderValue.floatValue - 0.5f) * amplificationSliderValue.floatValue * 2,
                         leftTone = toneSliderValue.floatValue,
@@ -157,7 +154,8 @@ fun HearingAidAdjustmentsScreen(@Suppress("unused") navController: NavController
                             toneSliderValue.floatValue = parsed.leftTone
                             ambientNoiseReductionSliderValue.floatValue = parsed.leftAmbientNoiseReduction
                             conversationBoostEnabled.value = parsed.leftConversationBoost
-                            eq.value = parsed.leftEQ.copyOf()
+                            leftEQ.value = parsed.leftEQ.copyOf()
+                            rightEQ.value = parsed.rightEQ.copyOf()
                             ownVoiceAmplification.floatValue = parsed.ownVoiceAmplification
                             Log.d(TAG, "Updated hearing aid settings from notification")
                         } else {
@@ -192,8 +190,8 @@ fun HearingAidAdjustmentsScreen(@Suppress("unused") navController: NavController
                 }
 
                 hearingAidSettings.value = HearingAidSettings(
-                    leftEQ = eq.value,
-                    rightEQ = eq.value,
+                    leftEQ = leftEQ.value,
+                    rightEQ = rightEQ.value,
                     leftAmplification = amplificationSliderValue.floatValue + if (balanceSliderValue.floatValue < 0) -balanceSliderValue.floatValue else 0f,
                     rightAmplification = amplificationSliderValue.floatValue + if (balanceSliderValue.floatValue > 0) balanceSliderValue.floatValue else 0f,
                     leftTone = toneSliderValue.floatValue,
@@ -215,26 +213,6 @@ fun HearingAidAdjustmentsScreen(@Suppress("unused") navController: NavController
                 try {
                     attManager.enableNotifications(ATTHandles.HEARING_AID)
                     attManager.registerListener(ATTHandles.HEARING_AID, hearingAidATTListener)
-
-                    try {
-                        if (aacpManager != null) {
-                            Log.d(TAG, "Found AACPManager, reading cached EQ data")
-                            val aacpEQ = aacpManager.eqData
-                            if (aacpEQ.isNotEmpty()) {
-                                eq.value = aacpEQ.copyOf()
-                                phoneMediaEQ.value = aacpEQ.copyOf()
-                                phoneEQEnabled.value = aacpManager.eqOnPhone
-                                mediaEQEnabled.value = aacpManager.eqOnMedia
-                                Log.d(TAG, "Populated EQ from AACPManager: ${aacpEQ.toList()}")
-                            } else {
-                                Log.d(TAG, "AACPManager EQ data empty")
-                            }
-                        } else {
-                            Log.d(TAG, "No AACPManager available")
-                        }
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Error reading EQ from AACPManager: ${e.message}")
-                    }
 
                     var parsedSettings: HearingAidSettings? = null
                     for (attempt in 1..3) {
@@ -261,7 +239,8 @@ fun HearingAidAdjustmentsScreen(@Suppress("unused") navController: NavController
                         toneSliderValue.floatValue = parsedSettings.leftTone
                         ambientNoiseReductionSliderValue.floatValue = parsedSettings.leftAmbientNoiseReduction
                         conversationBoostEnabled.value = parsedSettings.leftConversationBoost
-                        eq.value = parsedSettings.leftEQ.copyOf()
+                        leftEQ.value = parsedSettings.leftEQ.copyOf()
+                        rightEQ.value = parsedSettings.rightEQ.copyOf()
                         ownVoiceAmplification.floatValue = parsedSettings.ownVoiceAmplification
                         initialReadSucceeded.value = true
                     } else {


### PR DESCRIPTION
By copying the transparency customizations code to hearing aid settings, I overwrote the same eq (loss data) for both pods. And, by ATT didn't work, it would use the EQ from AACP, which was actually not linked to the hearing loss data at all.

---
ai gen'd sumamry:

This pull request refactors how hearing aid settings are managed in both the `HearingAidAdjustmentsScreen.kt` and `UpdateHearingTestScreen.kt` files. The main changes involve splitting the equalizer (EQ) state into separate left and right channels, removing unused phone/media EQ code, and improving the way UI state is handled for hearing aid configuration. These updates make the codebase more modular, easier to maintain, and ensure that individual hearing aid parameters are tracked and updated correctly.

### Hearing Aid EQ State Refactoring
* Split the single `eq` state into separate `leftEQ` and `rightEQ` states, updating all references to use these new variables for more accurate per-ear adjustments. [[1]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L99-L105) [[2]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L114-R112) [[3]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L160-R158) [[4]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L195-R194) [[5]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L264-R243) [[6]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL131-L164) [[7]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbR164-R168) [[8]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL208-R208) [[9]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbR243-R247)

### Removal of Unused and Redundant Code
* Removed all phone/media EQ state and related toggles, as well as legacy code for reading EQ data from the `AACPManager`, streamlining the state management and initialization logic. [[1]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L99-L105) [[2]](diffhunk://#diff-0045c8d2f573f06de120ab07343df3eeba225b7a4460cd4ad3133e70d9844273L219-L238) [[3]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL65) [[4]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL94) [[5]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL131-L164) [[6]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL230-L247)

### Improved State Management for UI Controls
* Added dedicated state variables for tone, ambient noise reduction, own voice amplification, and per-ear amplification, ensuring that these parameters are independently tracked and updated in the UI. [[1]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbR109-R127) [[2]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbR164-R168) [[3]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL208-R208) [[4]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbR243-R247)

### UI and Theming Enhancements
* Updated UI code to use dynamic text color based on the system theme and refactored `TextStyle` usage for better readability and maintainability.

### Cleanup of Legacy Hearing Aid Enable Logic
* Removed legacy logic related to hearing aid enablement and listeners that were previously tied to the `AACPManager`, further simplifying the codebase. [[1]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL131-L164) [[2]](diffhunk://#diff-b1cfa2e63a29227bcc88c462290b9e57be45d4695b7382aa0d83a8f0aef87bbbL181-R184)

These changes collectively enhance the modularity and clarity of hearing aid settings management in the app.