### PR TITLE
linux/README.md - add missing dependencies

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -43,6 +43,31 @@ A native Linux application to control your AirPods, with support for:
     # For Fedora
     sudo dnf install openssl-devel
     ```
+4. Libpulse development headers
+
+    ```bash
+    # On Arch Linux / EndevaourOS, these are included in the libpulse package, so you might already have them installed.
+    sudo pacman -S libpulse
+
+    # For Debian / Ubuntu
+    sudo apt-get install libpulse-dev
+
+    # For Fedora
+    sudo dnf install pulseaudio-libs-devel
+    ```
+5. Cmake
+
+    ```bash
+    # For Arch Linux / EndeavourOS
+    sudo pacman -S cmake
+
+    # For Debian / Ubuntu
+    sudo apt-get install cmake
+
+    # For Fedora
+    sudo dnf install cmake
+    ```
+
 ## Setup
 
 1. Build the application:


### PR DESCRIPTION
I tried installing the Linux app on a recent install of Ubuntu and ran into a few missing dependencies. I looked up the equivalent packages in Arch and Fedora and tested the new install commands in containers (archlinux:latest and fedora:latest).