### PR TITLE
fixed linux hearing aid bug

### DIFF
--- a/linux/hearing-aid-adjustments.py
+++ b/linux/hearing-aid-adjustments.py
@@ -4,7 +4,7 @@ import socket
 import struct
 import sys
 import threading
-from socket import socket as Socket, TimeoutError
+from socket import socket as Socket
 from queue import Queue
 from threading import Thread
 from typing import Any, Dict, List, Optional


### PR DESCRIPTION
tried to launch hearing-aid-adjustments.py and discovered a error:
```
vboxuser@ubuntu:~/Desktop/librepods/linux$ python3 hearing-aid-adjustments.py 38:C4:3A:26:11:CE
Traceback (most recent call last):
  File "/home/vboxuser/Desktop/librepods/linux/hearing-aid-adjustments.py", line 7, in <module>
    from socket import socket as Socket, TimeoutError
ImportError: cannot import name 'TimeoutError' from 'socket' (/usr/lib/python3.12/socket.py)
```

turns out this happened because of refactoring in 0a608afbe6124b82a2900fe95ff75f763d1f6c78, ironic. with my commit everything works well, i recommend to check other files in that commit