### PR TITLE
linux: add build requirement to Linux instructions

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -9,8 +9,8 @@ A native Linux application to control your AirPods, with support for:
 - Battery monitoring
 - Auto play/pause on ear detection
 - Hearing Aid features
-   - Supports adjusting hearing aid- amplification, balance, tone, ambient noise reduction, own voice amplification, and conversation boost
-   - Supports setting the values for left and right hearing aids (this is not a hearing test! you need to have an audiogram to set the values)
+  - Supports adjusting hearing aid- amplification, balance, tone, ambient noise reduction, own voice amplification, and conversation boost
+  - Supports setting the values for left and right hearing aids (this is not a hearing test! you need to have an audiogram to set the values)
 - Seamless handoff between Android and Linux
 
 ## Prerequisites
@@ -25,12 +25,13 @@ A native Linux application to control your AirPods, with support for:
    # For Debian
    sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
         qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
-        qml6-module-qtquick-window qml6-module-qtquick-layouts
+        qml6-module-qtquick-window qml6-module-qtquick-layouts qt6-tools-dev
 
     # For Fedora
     sudo dnf install qt6-qtbase-devel qt6-qtconnectivity-devel \
         qt6-qtmultimedia-devel qt6-qtdeclarative-devel
    ```
+
 3. OpenSSL development headers
 
     ```bash
@@ -43,6 +44,7 @@ A native Linux application to control your AirPods, with support for:
     # For Fedora
     sudo dnf install openssl-devel
     ```
+
 4. Libpulse development headers
 
     ```bash
@@ -55,6 +57,7 @@ A native Linux application to control your AirPods, with support for:
     # For Fedora
     sudo dnf install pulseaudio-libs-devel
     ```
+
 5. Cmake
 
     ```bash


### PR DESCRIPTION
There was a missing package needed for compiling the Linux version under Ubuntu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux installation prerequisites and setup documentation with clarified package requirements, including additional development libraries for improved setup guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->