### PR TITLE
linux(i18n): add Italian translations

### DIFF
--- a/linux/translations/librepods_it_IT.ts
+++ b/linux/translations/librepods_it_IT.ts
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it_IT">
+<context>
+    <name>Main</name>
+    <message>
+        <source>Connected</source>
+        <translation>Connesso</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Disconnesso</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Non attivo</translation>
+    </message>
+    <message>
+        <source>Noise Cancellation</source>
+        <translation>Cancellazione rumore</translation>
+    </message>
+    <message>
+        <source>Transparency</source>
+        <translation>Trasparenza</translation>
+    </message>
+    <message>
+        <source>Adaptive</source>
+        <translation>Adattivo</translation>
+    </message>
+    <message>
+        <source>Adaptive Noise Level: </source>
+        <translation>Livello rumore adattivo: </translation>
+    </message>
+    <message>
+        <source>Conversational Awareness</source>
+        <translation>Rilevamento conversazione</translation>
+    </message>
+    <message>
+        <source>Hearing Aid</source>
+        <translation>Apparecchio acustico</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
+    </message>
+    <message>
+        <source>Pause Behavior When Removing AirPods:</source>
+        <translation>Pausa alla rimozione delle AirPods:</translation>
+    </message>
+    <message>
+        <source>One Removed</source>
+        <translation>Una rimossa</translation>
+    </message>
+    <message>
+        <source>Both Removed</source>
+        <translation>Entrambe rimosse</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation>Mai</translation>
+    </message>
+    <message>
+        <source>Cross-Device Connectivity with Android</source>
+        <translation>Connettività multi-dispositivo con Android</translation>
+    </message>
+    <message>
+        <source>Auto-Start on Login</source>
+        <translation>Avvio automatico all'accesso</translation>
+    </message>
+    <message>
+        <source>Enable System Notifications</source>
+        <translation>Abilita notifiche di sistema</translation>
+    </message>
+    <message>
+        <source>One Bud ANC Mode</source>
+        <translation>Modalità ANC singolo auricolare</translation>
+    </message>
+    <message>
+        <source>Enable ANC when using one AirPod
+(More noise reduction, but uses more battery)</source>
+        <translation>Abilita ANC con un solo AirPod
+(Maggiore riduzione rumore, ma consuma più batteria)</translation>
+    </message>
+    <message>
+        <source>Bluetooth Retry Attempts:</source>
+        <translation>Tentativi riprova Bluetooth:</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Rinomina</translation>
+    </message>
+    <message>
+        <source>Change Phone MAC</source>
+        <translation>Cambia MAC Telefono</translation>
+    </message>
+    <message>
+        <source>Show Magic Cloud Keys QR</source>
+        <translation>Mostra QR Magic Cloud Keys</translation>
+    </message>
+</context>
+<context>
+    <name>TrayIconManager</name>
+    <message>
+        <source>Battery Status: </source>
+        <translation>Stato batteria: </translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Apri</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
+    </message>
+    <message>
+        <source>Toggle Conversational Awareness</source>
+        <translation>Attiva/Disattiva Rilevamento conversazione</translation>
+    </message>
+    <message>
+        <source>Adaptive</source>
+        <translation>Adattivo</translation>
+    </message>
+    <message>
+        <source>Transparency</source>
+        <translation>Trasparenza</translation>
+    </message>
+    <message>
+        <source>Noise Cancellation</source>
+        <translation>Cancellazione rumore</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Non attivo</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Esci</translation>
+    </message>
+</context>
+<context>
+    <name>AirPodsTrayApp</name>
+    <message>
+        <source>AirPods Disconnected</source>
+        <translation>AirPods disconnesse</translation>
+    </message>
+    <message>
+        <source>Your AirPods have been disconnected</source>
+        <translation>Le tue AirPods sono state disconnesse</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
As the title suggests, the translation has been added for the Linux app - the Android app already had the Italian translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Italian language translations for the application, including status indicators (Connected, Disconnected, Off), feature labels (Noise Cancellation, Transparency, Adaptive), settings and actions, tray icon options, and notification messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->