### PR TITLE
Add missing libs in debian linux build and add linux dektop entry

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -81,15 +81,23 @@ target_link_libraries(librepods
 target_include_directories(librepods PRIVATE ${PULSEAUDIO_INCLUDE_DIRS})
 
 include(GNUInstallDirs)
+
+# Install the binary
 install(TARGETS librepods
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+# Install desktop entry
 install(FILES assets/me.kavishdevar.librepods.desktop
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
+)
+
+# Install icon
 install(FILES assets/librepods.png
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/512x512/apps")
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/512x512/apps"
+)
 
 # Translation support
 qt_add_translations(librepods
@@ -99,4 +107,16 @@ qt_add_translations(librepods
 
 # Install translation files
 install(FILES ${QM_FILES}
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/librepods/translations")
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/librepods/translations"
+)
+
+# --------------------------------------------------------------
+# Update icon and desktop caches after installation
+# --------------------------------------------------------------
+install(CODE "
+    message(STATUS \"Updating icon cache...\")
+    execute_process(COMMAND update-icon-caches ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor)
+
+    message(STATUS \"Updating desktop database...\")
+    execute_process(COMMAND update-desktop-database ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+")

--- a/linux/README.md
+++ b/linux/README.md
@@ -24,8 +24,10 @@ A native Linux application to control your AirPods, with support for:
 
    # For Debian
    sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
-        qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
-        qml6-module-qtquick-window qml6-module-qtquick-layouts
+    qt6-base-dev-tools qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools libxkbcommon-dev \
+    qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
+    qml6-module-qtquick-window qml6-module-qtquick-layouts build-essential cmake ninja-build
+
 
     # For Fedora
     sudo dnf install qt6-qtbase-devel qt6-qtconnectivity-devel \
@@ -83,6 +85,14 @@ A native Linux application to control your AirPods, with support for:
 
    ```bash
    ./librepods
+   ```
+3. (Optional) Install system-wide desktop entry + icon
+   ```
+   sudo make install
+   ```
+   After this, you can launch LibrePods from your desktop menu or run:
+   ```
+   librepods
    ```
 
 ## Troubleshooting

--- a/linux/README.md
+++ b/linux/README.md
@@ -87,9 +87,9 @@ A native Linux application to control your AirPods, with support for:
    ./librepods
    ```
 3. (Optional) Install system-wide desktop entry + icon
-   ```
-   sudo make install
    ```bash
+   sudo make install
+   ```
    After this, you can launch LibrePods from your desktop menu or run:
    ```bash
    librepods

--- a/linux/README.md
+++ b/linux/README.md
@@ -89,9 +89,9 @@ A native Linux application to control your AirPods, with support for:
 3. (Optional) Install system-wide desktop entry + icon
    ```
    sudo make install
-   ```
+   ```bash
    After this, you can launch LibrePods from your desktop menu or run:
-   ```
+   ```bash
    librepods
    ```
 


### PR DESCRIPTION
1. Add : **Missing Libs in debian linux build** (attaching initial failed build logs)
2. Add **Desktop Entry with Icon** (Optional - users can run a command to have it) - its hard to go to build folders and rerun the commands for naive users instead anyone can have the Desktop Entry Like normal apps.

Failed Build Logs:
<details>
  <summary>View build error log</summary>

```log
~/librepods/librepods/linux/build$ cmake ..
-- Could NOT find XKB (missing: XKB_LIBRARY XKB_INCLUDE_DIR) (Required is at least version "0.5.0")
-- Could NOT find Qt6LinguistTools (missing: Qt6LinguistTools_DIR)
CMake Error at CMakeLists.txt:7 (find_package):
  Found package configuration file: /usr/lib/x86_64-linux-gnu/cmake/Qt6/Qt6Config.cmake
  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT FOUND.
  Reason given by package: Failed to find required Qt component "LinguistTools".
  Expected Config file at "/usr/lib/x86_64-linux-gnu/cmake/Qt6LinguistTools/Qt6LinguistToolsConfig.cmake" does NOT exist
Configuring with --debug-find-pkg=Qt6LinguistTools might reveal details why the package was not found.
Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some of the path variables that find_package uses to try and find the package.
-- Configuring incomplete, errors occurred!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Linux build prerequisites to include additional Qt6 development tools and build dependencies.
  * Added optional setup steps to install a system-wide desktop entry and icon, plus instructions to launch the app from the desktop menu.

* **Chores**
  * Added a post-install step to refresh system icon caches and the desktop database on Linux.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->