### PR TITLE
[Linux] Fix ear detection pause/resume with playerctl fallback

### DIFF
--- a/linux/media/mediacontroller.cpp
+++ b/linux/media/mediacontroller.cpp
@@ -49,13 +49,12 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
     shouldResume = primaryInEar || secondaryInEar;
   }
 
-  if (shouldPause && isActiveOutputDeviceAirPods())
+  // Pause if conditions are met (removed isActiveOutputDeviceAirPods check as it
+  // fails on some systems where PulseAudio can't detect the Bluetooth card)
+  if (shouldPause)
   {
-    if (getCurrentMediaState() == Playing)
-    {
-      LOG_DEBUG("Pausing playback for ear detection");
-      pause();
-    }
+    LOG_INFO("Ear detection triggered pause");
+    pause();
   }
 
   // Then handle device profile switching
@@ -65,8 +64,9 @@ void MediaController::handleEarDetection(EarDetection *earDetection)
     activateA2dpProfile();
 
     // Resume if conditions are met and we previously paused
-    if (shouldResume && !pausedByAppServices.isEmpty() && isActiveOutputDeviceAirPods())
+    if (shouldResume && !pausedByAppServices.isEmpty())
     {
+      LOG_INFO("Ear detection triggered resume");
       play();
     }
   }
@@ -307,6 +307,24 @@ void MediaController::play()
     return;
   }
 
+  // If we paused via playerctl fallback, resume via playerctl
+  if (pausedByAppServices.contains("playerctl"))
+  {
+    LOG_INFO("Resuming media via playerctl");
+    int result = QProcess::execute("playerctl", QStringList() << "play");
+    if (result == 0)
+    {
+      LOG_INFO("Resumed media via playerctl");
+      pausedByAppServices.clear();
+    }
+    else
+    {
+      LOG_WARN("playerctl play returned: " << result);
+    }
+    return;
+  }
+
+  // Try to resume via DBus
   QDBusConnection bus = QDBusConnection::sessionBus();
   int resumedCount = 0;
 
@@ -400,7 +418,18 @@ void MediaController::pause()
   }
   else
   {
-    LOG_INFO("No playing media players found to pause");
+    // Fallback to playerctl if DBus didn't find any playing media
+    LOG_INFO("No playing media found via DBus, trying playerctl fallback");
+    int result = QProcess::execute("playerctl", QStringList() << "pause");
+    if (result == 0)
+    {
+      LOG_INFO("Paused media via playerctl fallback");
+      pausedByAppServices << "playerctl";
+    }
+    else
+    {
+      LOG_DEBUG("playerctl fallback returned: " << result);
+    }
   }
 }
 


### PR DESCRIPTION
- Remove isActiveOutputDeviceAirPods() check from pause/resume logic as it fails on some systems where PulseAudio can't detect the Bluetooth card properly

- Add playerctl as fallback when DBus MPRIS doesn't find playing media players. This fixes compatibility with browsers and players that don't register properly with DBus on certain systems

- Resume logic now correctly uses playerctl if that's how media was paused

Fixes ear detection not pausing media on aarch64 Ubuntu systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed media pause and resume functionality to work reliably on all audio devices
  * Enhanced reliability of pause and resume operations with improved fallback handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->