### PR TITLE
fix(linux): correct single-instance detection order

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -1010,25 +1010,23 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    QLocalServer::removeServer("app_server");
-
-    QFile stale("/tmp/app_server");
-    if (stale.exists())
-        stale.remove();
-
     QLocalSocket socket_check;
     socket_check.connectToServer("app_server");
 
     if (socket_check.waitForConnected(300)) {
         LOG_INFO("Another instance already running! Reopening window...");
-
         socket_check.write("reopen");
         socket_check.flush();
         socket_check.waitForBytesWritten(200);
         socket_check.disconnectFromServer();
-
         return 0;
     }
+
+    QLocalServer::removeServer("app_server");
+    QFile stale("/tmp/app_server");
+    if (stale.exists())
+        stale.remove();
+
     app.setDesktopFileName("me.kavishdevar.librepods");
     app.setQuitOnLastWindowClosed(false);
 

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -1023,9 +1023,6 @@ int main(int argc, char *argv[]) {
     }
 
     QLocalServer::removeServer("app_server");
-    QFile stale("/tmp/app_server");
-    if (stale.exists())
-        stale.remove();
 
     app.setDesktopFileName("me.kavishdevar.librepods");
     app.setQuitOnLastWindowClosed(false);
@@ -1114,9 +1111,6 @@ int main(int argc, char *argv[]) {
         }
 
         QLocalServer::removeServer("app_server");
-        QFile stale("/tmp/app_server");
-        if (stale.exists())
-            stale.remove();
     });
     return app.exec();
 }


### PR DESCRIPTION
### problem

When launching the app while an instance is already running, a new instance starts instead of bringing the existing window to focus. This results in duplicate system tray icons.

The socket cleanup was running BEFORE the connection check,causing every new launch to delete the socket before attempting to detect an existing instance.

### solution

Reorder the logic in `main()`:
1. **First** - Attempt to connect to existing server
2. **If connected** - Send "reopen" message and exit (another instance is running)
3. **If connection fails** - Clean up any stale socket files, then start the server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup cleanup so temporary IPC artifacts are only removed when the app proceeds as the active instance; this prevents accidental removal when another instance is running and preserves cleanup after quit. No changes to public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->