### PR TITLE
fix: Fixing qt package not found error during cmake step by adding th…

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -25,7 +25,7 @@ A native Linux application to control your AirPods, with support for:
    # For Debian
    sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
         qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
-        qml6-module-qtquick-window qml6-module-qtquick-layouts
+        qml6-module-qtquick-window qml6-module-qtquick-layouts qt6-tools-dev
 
     # For Fedora
     sudo dnf install qt6-qtbase-devel qt6-qtconnectivity-devel \


### PR DESCRIPTION
…e correct package for ubuntu 25.10 questing<

For Ubuntu 25.10 questing, I got an error saying that it could not find a qt dependency while executing the cmake step:

main ~/apps/librepods/linux/build> cmake ..
-- Could NOT find Qt6LinguistTools (missing: Qt6LinguistTools_DIR)
CMake Error at CMakeLists.txt:7 (find_package):
  Found package configuration file:

    /usr/lib/x86_64-linux-gnu/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "LinguistTools".

  Expected Config file at
  "/usr/lib/x86_64-linux-gnu/cmake/Qt6LinguistTools/Qt6LinguistToolsConfig.cmake"
  does NOT exist



  Configuring with --debug-find-pkg=Qt6LinguistTools might reveal details why
  the package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.



-- Configuring incomplete, errors occurred!
exit 1



I fixed it installing the package sudo apt install qt6-tools-dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux Debian installation instructions with an additional Qt6 development package for comprehensive build support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->