### PR TITLE
fix: update radare2 download source to GitHub releases

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/RadareOffsetFinder.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/RadareOffsetFinder.kt
@@ -40,7 +40,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 class RadareOffsetFinder(context: Context) {
     companion object {
         private const val TAG = "RadareOffsetFinder"
-        private const val RADARE2_URL = "https://hc-cdn.hel1.your-objectstorage.com/s/v3/c9898243c42c0d3d1387de9a37d57ce9df77f9c9_radare2-5.9.9-android-aarch64.tar.gz"
+        private const val RADARE2_URL = "https://github.com/devnoname120/radare2/releases/download/5.9.8-android-aln/radare2-5.9.9-android-aarch64-aln.tar.gz"
         private const val HOOK_OFFSET_PROP = "persist.librepods.hook_offset"
         private const val CFG_REQ_OFFSET_PROP = "persist.librepods.cfg_req_offset"
         private const val CSM_CONFIG_OFFSET_PROP = "persist.librepods.csm_config_offset"

--- a/build-magisk-module.sh
+++ b/build-magisk-module.sh
@@ -7,5 +7,5 @@ rm -f ../btl2capfix.zip
 
 # COPYFILE_DISABLE env is a macOS fix to avoid parasitic files in ZIPs: https://superuser.com/a/260264
 export COPYFILE_DISABLE=1
-curl -L -o ./radare2-5.9.9-android-aarch64.tar.gz "https://hc-cdn.hel1.your-objectstorage.com/s/v3/25e8dbfe13892b4c26f3e01bfa45197f170bb0e7_radare2-5.9.9-android-aarch64.tar.gz"
+curl -L -o ./radare2-5.9.9-android-aarch64.tar.gz "https://github.com/devnoname120/radare2/releases/download/5.9.8-android-aln/radare2-5.9.9-android-aarch64-aln.tar.gz"
 zip -r ../btl2capfix.zip . -x \*.DS_Store \*__MACOSX \*DEBIAN ._\* .gitignore


### PR DESCRIPTION
This PR updates the download URL for the `radare2` binary used in both the Android application and the Magisk module build script.

The previous `your-objectstorage.com` links have become unreliable or offline, leading to the setup failures reported by multiple users in **#439**. This change migrates the source to official GitHub release assets provided by `devnoname120` (`5.9.8-android-aln`), i hope that is the correct one.

### Changes

* **`RadareOffsetFinder.kt`**: Updated `RADARE2_URL` to point to the new GitHub release asset.
* **`build-magisk-module.sh`**: Updated the `curl` target to ensure the Magisk module builds with a valid binary.

### Linked Issues

* **Fixes #439**: Resolves "Failure to install Radare2 Tarball in setup".

### Testing & Verification

> [!IMPORTANT]
> **Partial Verification:** I have verified that the new URLs are reachable and the files are being pulled correctly. However, I am currently unable to perform a full end-to-end connection test due to the ongoing L2CAP connection issues on the Pixel 7a (as documented in **#229**).
> Despite the socket timeout/PSM issues on my specific hardware, this PR successfully fixes the **installation phase** of the setup, which was previously failing for everyone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated radare2 dependency download sources to GitHub releases for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->