### PR TITLE
fix(linux-rust): Clear stale tray battery on device switch

### DIFF
--- a/linux-rust/src/devices/airpods.rs
+++ b/linux-rust/src/devices/airpods.rs
@@ -34,7 +34,17 @@ impl AirPodsDevice {
 
         if let Some(handle) = &tray_handle {
             handle
-                .update(|tray: &mut MyTray| tray.connected = true)
+                .update(|tray: &mut MyTray| {
+                    tray.connected = true;
+                    tray.battery_headphone = None;
+                    tray.battery_headphone_status = None;
+                    tray.battery_l = None;
+                    tray.battery_l_status = None;
+                    tray.battery_r = None;
+                    tray.battery_r_status = None;
+                    tray.battery_c = None;
+                    tray.battery_c_status = None;
+                })
                 .await;
         }
 


### PR DESCRIPTION
### Problem
When switching from Airpods Max to Airpods (or vice versa), the tray displays battery data from the previous device. Airpods populates `battery_l`, `battery_r`, `battery_c` while Airpods Max populates `battery_headphone`, the old fields are never cleared so the tray icon doesn't update.

### Fix
Reset all battery fields to `None` when a new device connects, so only the active device's data is shown.