### PR TITLE
fix: add missing word in build-magisk-module.sh

### DIFF
--- a/build-magisk-module.sh
+++ b/build-magisk-module.sh
@@ -7,5 +7,5 @@ rm -f ../btl2capfix.zip
 
 # COPYFILE_DISABLE env is a macOS fix to avoid parasitic files in ZIPs: https://superuser.com/a/260264
 export COPYFILE_DISABLE=1
-curl -L -o ./radare2-5.9.9-android-aarch64.tar.gz "https://github.com/devnoname120/radare2/releases/download/5.9.8-android-aln/radare2-5.9.9-android-aarch64-aln.tar.gz"
+curl -L -o ./radare2-5.9.9-android-aarch64-aln.tar.gz "https://github.com/devnoname120/radare2/releases/download/5.9.8-android-aln/radare2-5.9.9-android-aarch64-aln.tar.gz"
 zip -r ../btl2capfix.zip . -x \*.DS_Store \*__MACOSX \*DEBIAN ._\* .gitignore


### PR DESCRIPTION
The script was broken because of a missing word.This PR adds the missing word to make the script usable again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script dependency handling for improved version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->