### PR TITLE
Update README with additional Qt6 package instructions

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -20,16 +20,16 @@ A native Linux application to control your AirPods, with support for:
 
    ```bash
    # For Arch Linux / EndeavourOS
-   sudo pacman -S qt6-base qt6-connectivity qt6-multimedia-ffmpeg qt6-multimedia
+   sudo pacman -S qt6-base qt6-connectivity qt6-multimedia-ffmpeg qt6-multimedia qt6-tools
 
    # For Debian
    sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
         qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
-        qml6-module-qtquick-window qml6-module-qtquick-layouts
+        qml6-module-qtquick-window qml6-module-qtquick-layouts qt6-linguist-tools
 
     # For Fedora
     sudo dnf install qt6-qtbase-devel qt6-qtconnectivity-devel \
-        qt6-qtmultimedia-devel qt6-qtdeclarative-devel
+        qt6-qtmultimedia-devel qt6-qtdeclarative-devel qt6-linguist
    ```
 3. OpenSSL development headers
 


### PR DESCRIPTION
Added qt6-tools and qt6-linguist-tools to installation instructions for Arch Linux, Debian, and Fedora.

The package was missing before and I got a cmake error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux setup instructions with additional Qt6 tooling package requirements:
    * Arch/EndeavourOS: qt6-tools
    * Debian: qt6-linguist-tools
    * Fedora: qt6-linguist

<!-- end of auto-generated comment: release notes by coderabbit.ai -->