### PR TITLE
fix: ensure safe extraction of radare2 tarball

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/RadareOffsetFinder.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/RadareOffsetFinder.kt
@@ -300,7 +300,7 @@ class RadareOffsetFinder(context: Context) {
             Log.d(TAG, "Extracting ${radare2TarballFile.absolutePath} to $EXTRACT_DIR")
 
             val process = Runtime.getRuntime().exec(
-                arrayOf("su", "-c", "tar xvf ${radare2TarballFile.absolutePath} -C $EXTRACT_DIR")
+                arrayOf("su", "-c", "tar xvf ${radare2TarballFile.absolutePath} --no-same-owner -m -p -C $EXTRACT_DIR")
             )
 
             val reader = BufferedReader(InputStreamReader(process.inputStream))


### PR DESCRIPTION
On some AOSP builds, the default 'tar' behavior is inconsistent and
may attempt to overwrite the permissions of the destination root
directory. This often leads to permission denied errors or command
failures when extracting as root.

This commit adds '--no-same-owner', '-m', and '-p' flags to mitigate
these issues. Specifically, it prevents tar from attempting to preserve
original ownership and ensures that file modification times and
permissions are handled more predictably during extraction to the
target directory.

Signed-off-by: qwq233 <qwq233@qwq2333.top>

```
03-13 13:55:31.609  3206  8609 E RadareOffsetFinder: Extract error: tar: chown 1000:1000 './': Read-only file system
03-13 13:55:31.609  3206  8609 E RadareOffsetFinder: Extract error: tar: settime 1744014133 ./: Read-only file system
03-13 13:55:31.609  3206  8609 E RadareOffsetFinder: Extract error: tar: had errors
03-13 13:55:31.609  3206  8609 E RadareOffsetFinder: Extraction failed with exit code 1
```
