### PR TITLE
feat(linux): added librepods-ctl CLI tool for IPC control

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -78,6 +78,16 @@ target_link_libraries(librepods
     PRIVATE Qt6::Quick Qt6::Widgets Qt6::Bluetooth Qt6::DBus OpenSSL::SSL OpenSSL::Crypto ${PULSEAUDIO_LIBRARIES}
 )
 
+qt_add_executable(librepods-ctl
+    librepods-ctl.cpp
+)
+target_link_libraries(librepods-ctl
+    PRIVATE Qt6::Core Qt6::Network
+)
+install(TARGETS librepods-ctl
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
 target_include_directories(librepods PRIVATE ${PULSEAUDIO_INCLUDE_DIRS})
 
 include(GNUInstallDirs)

--- a/linux/README.md
+++ b/linux/README.md
@@ -129,6 +129,35 @@ systemctl --user enable --now mpris-proxy
   - View battery levels
   - Control playback
 
+
+## CLI Control
+
+`librepods-ctl` is a small command-line tool that lets you access LibrePods from the terminal or via scripts, as long as the main application is running.
+
+### Usage
+```bash
+librepods-ctl
+```
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `noise:off` | Disable noise control |
+| `noise:anc` | Enable Active Noise Cancellation |
+| `noise:transparency` | Enable Transparency mode |
+| `noise:adaptive` | Enable Adaptive mode |
+
+### Example
+```bash
+# Enable ANC
+librepods-ctl noise:anc
+
+# Enable Transparency mode
+librepods-ctl noise:transparency
+```
+
+
 ## Hearing Aid
 
 To use hearing aid features, you need to have an audiogram. To enable/disable hearing aid, you can use the toggle in the main app. But, to adjust the settings and set the audiogram, you need to use a different script which is located in this folder as `hearing_aid.py`. You can run it with:

--- a/linux/librepods-ctl.cpp
+++ b/linux/librepods-ctl.cpp
@@ -1,0 +1,31 @@
+#include <QCoreApplication>
+#include <QLocalSocket>
+#include <QTextStream>
+
+int main(int argc, char *argv[]) {
+    QCoreApplication app(argc, argv);
+
+    if (argc < 2) {
+        QTextStream(stderr) << "Usage: librepods-ctl <command>\n"
+                            << "Commands:\n"
+                            << "  noise:off           Disable noise control\n"
+                            << "  noise:anc           Enable Active Noise Cancellation\n"
+                            << "  noise:transparency  Enable Transparency mode\n"
+                            << "  noise:adaptive      Enable Adaptive mode\n";
+        return 1;
+    }
+
+    QLocalSocket socket;
+    socket.connectToServer("app_server");
+
+    if (!socket.waitForConnected(500)) {
+        QTextStream(stderr) << "Could not connect to librepods (is it running?)\n";
+        return 1;
+    }
+
+    socket.write(QByteArray(argv[1]));
+    socket.flush();
+    socket.waitForBytesWritten(200);
+    socket.disconnectFromServer();
+    return 0;
+}

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -1089,6 +1089,18 @@ int main(int argc, char *argv[]) {
                     trayApp->loadMainModule();
                 }
             }
+            else if (msg == "noise:off") {
+                trayApp->setNoiseControlModeInt(0);
+            }
+            else if (msg == "noise:anc") {
+                trayApp->setNoiseControlModeInt(1);
+            }
+            else if (msg == "noise:transparency") {
+                trayApp->setNoiseControlModeInt(2);
+            }
+            else if (msg == "noise:adaptive") {
+                trayApp->setNoiseControlModeInt(3);
+            }
             else
             {
                 LOG_ERROR("Unknown message received: " << msg);


### PR DESCRIPTION
Relates to #477 

Adds basic CLI control over the QLocalServer as a lightweight temporary solution until the planned D-Bus IPC is implemented. 

## Changes
- Extends the socket message handler to support CLI commands.
- Adds `librepods-ctl` binary for scripting and shell integration.
- Added CLI usage within the Linux README.

## Usage
```bash
librepods-ctl noise:anc
librepods-ctl noise:transparency
librepods-ctl noise:off
librepods-ctl noise:adaptive
```