### PR TITLE
fix(linux-rust): Retry L2CAP send on ENOTCONN during BlueZ Handshake

### DIFF
--- a/linux-rust/src/bluetooth/aacp.rs
+++ b/linux-rust/src/bluetooth/aacp.rs
@@ -1191,11 +1191,23 @@ async fn recv_thread(manager: AACPManager, sp: Arc<SeqPacket>) {
 
 async fn send_thread(mut rx: mpsc::Receiver<Vec<u8>>, sp: Arc<SeqPacket>) {
     while let Some(data) = rx.recv().await {
-        if let Err(e) = sp.send(&data).await {
-            error!("Failed to send data: {}", e);
-            break;
+        let mut attempts = 0;
+        loop {
+          match sp.send(&data).await {
+            Ok(_) => {
+              debug!("Sent {} bytes: {}", data.len(), hex::encode(&data));
+              break;
+            }
+            Err(e) if e.raw_os_error() == Some(107) && attempts < 10 => {
+              attempts += 1;
+              sleep(Duration::from_millis(100)).await;
+            }
+            Err(e) => {
+              error!("Failed to send data: {}", e);
+              return;
+            }
+          }
         }
-        debug!("Sent {} bytes: {}", data.len(), hex::encode(&data));
     }
     info!("Send thread finished.");
 }


### PR DESCRIPTION
## Problem
When BlueZ reports the L2CAP connection as established, the kernel 
socket isn't always ready to accept writes yet. The send_thread was 
breaking on the first ENOTCONN (os error 107), killing the channel 
before the handshake could complete. This caused all subsequent sends 
(feature flags, notification request) to fail with "channel closed".

## Fix
Retry up to 10 times with 100ms backoff specifically on ENOTCONN 
before treating it as a fatal error. Any other error still kills 
the thread immediately.

Related to #288