### PR TITLE
android: Fix rename packet using wrong opcode (0x1E → 0x1A)

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/AACPManager.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/AACPManager.kt
@@ -43,7 +43,7 @@ class AACPManager {
             const val EAR_DETECTION: Byte = 0x06
             const val CONVERSATION_AWARENESS: Byte = 0x4B
             const val INFORMATION: Byte = 0x1D
-            const val RENAME: Byte = 0x1E
+            const val RENAME: Byte = 0x1A
             const val HEADTRACKING: Byte = 0x17
             const val PROXIMITY_KEYS_REQ: Byte = 0x30
             const val PROXIMITY_KEYS_RSP: Byte = 0x31
@@ -773,9 +773,10 @@ class AACPManager {
         val packet = ByteArray(5 + size)
         packet[0] = Opcodes.RENAME
         packet[1] = 0x00
-        packet[2] = size.toByte()
-        packet[3] = 0x00
-        System.arraycopy(nameBytes, 0, packet, 4, size)
+        packet[2] = 0x01
+        packet[3] = size.toByte()
+        packet[4] = 0x00
+        System.arraycopy(nameBytes, 0, packet, 5, size)
 
         return packet
     }


### PR DESCRIPTION
## What changed

`createRenamePacket` was using opcode `0x1E` with a trailing NUL. Modern AirPods silently drop this format: the command goes out, the device never echoes `0x001D`, and the name doesn't persist across reconnect.

Switched to the format already documented in `AAP Definitions.md` and used by `linux/airpods_packets.h`:

```
04 00 04 00 1A 00 01 [size] 00 [name]
```

## Verified

On AirPods Pro 2 USB-C (firmware `81.2675000075000000.6082`, Pixel 8, Android 15), via my own app ([d4rken-org/capod](https://github.com/d4rken-org/capod)):

- **Before**: `Sent SetDeviceName (36 bytes)` → no `0x001D` echo, name reverts on reconnect.
- **After**: force-stop, relaunch, fresh handshake → `Device info: CAPodTest (A3048)` — the device echoes the new name.

## Related to #411

Reporter's Pro 3 symptom ("rename doesn't show on my other phone") is consistent with the 0x1E packet being discarded — LibrePods' own UI showed the rename because `AirPodsService.setName()` writes to SharedPreferences, but nothing actually committed to the device. I'd leave #411 open: even with this fix, the "globally" part depends on other devices' own Bluetooth name caching and Android's per-phone alias (which needs `BluetoothDevice.setAlias()`, itself CDM-gated on Android 12+), so there may still be something worth tracking there.

## Caveats

Tested only on Pro 2 USB-C. Worth confirming on Pro 1 / Pro 3 / AP4 ANC / Max before landing. Same fix is shipping in [d4rken-org/capod#490](https://github.com/d4rken-org/capod/pull/490).