### PR TITLE
Fix bypass_device_check.v2 being silently ignored

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/RootlessSupport.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/RootlessSupport.kt
@@ -24,6 +24,9 @@ import android.os.Build
 fun isSupported(sharedPreferences: SharedPreferences): Boolean {
     val isPixel = Build.MANUFACTURER.lowercase() == "google"
     val isOppoOrOnePlus = Build.MANUFACTURER.lowercase() in listOf("oneplus", "oppo")
+    val isBypassFlagActive = sharedPreferences.getBoolean("bypass_device_check.v2", false)
+
+    if (isBypassFlagActive) return true
 
     if (isPixel) {
         when (Build.VERSION.SDK_INT) {
@@ -38,5 +41,5 @@ fun isSupported(sharedPreferences: SharedPreferences): Boolean {
     } else if (isOppoOrOnePlus) {
         return Build.VERSION.SDK_INT >= 36
     }
-    return sharedPreferences.getBoolean("bypass_device_check.v2", false)
+    return false
 }


### PR DESCRIPTION
The bypass_device_check.v2 SharedPreference was silently ignored, this makes the bypass work on all devices.
Tested on GrapheneOS (Pixel, Android 16).

Note: this naturally does not make librepods work on other devices than rooted and supported ones, but it gives the possibility to test and debug the functionality on unsupported configurations rather than being gated out at the device check.