### PR TITLE
ci(nix): automate weekly flake.lock updates on linux/rust

### DIFF
--- a/.github/workflows/ci-nix-flake-update.yml
+++ b/.github/workflows/ci-nix-flake-update.yml
@@ -16,10 +16,14 @@ concurrency:
 jobs:
   update-lock:
     runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: linux/rust
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
@@ -51,20 +55,21 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add flake.lock
           git commit -m "chore(nix): update flake.lock"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "HEAD:${TARGET_BRANCH}"
 
       # - name: Open pull request with lockfile changes
       #   if: steps.lockfile.outputs.changed == 'true'
       #   uses: peter-evans/create-pull-request@v7
       #   with:
       #     branch: ci/weekly-flake-lock
+      #     base: ${{ env.TARGET_BRANCH }}
       #     delete-branch: true
       #     commit-message: "chore(nix): update flake.lock"
       #     title: "chore(nix): update flake.lock"
       #     body: |
       #       Automated weekly flake input update.
       #
-      #       This PR was created by `.github/workflows/update-flake-lock.yml`.
+      #       This PR was created by `.github/workflows/ci-nix-flake-update.yml`.
       #     labels: |
       #       dependencies
       #       nix

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,70 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  # pull-requests: write
+
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: false
+
+jobs:
+  update-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v17
+
+      - name: Update flake lockfile
+        run: nix flake update
+
+      - name: Detect lockfile changes
+        id: lockfile
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate flake (no builds)
+        if: steps.lockfile.outputs.changed == 'true'
+        run: nix flake check --no-build
+
+      - name: Build default package
+        if: steps.lockfile.outputs.changed == 'true'
+        run: nix build .#default
+
+      - name: Commit and push lockfile changes
+        if: steps.lockfile.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.lock
+          git commit -m "chore(nix): update flake.lock"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+
+      # - name: Open pull request with lockfile changes
+      #   if: steps.lockfile.outputs.changed == 'true'
+      #   uses: peter-evans/create-pull-request@v7
+      #   with:
+      #     branch: ci/weekly-flake-lock
+      #     delete-branch: true
+      #     commit-message: "chore(nix): update flake.lock"
+      #     title: "chore(nix): update flake.lock"
+      #     body: |
+      #       Automated weekly flake input update.
+      #
+      #       This PR was created by `.github/workflows/update-flake-lock.yml`.
+      #     labels: |
+      #       dependencies
+      #       nix


### PR DESCRIPTION
## Linked Issues
Closes #550 

## What Changed
- Added workflow: `.github/workflows/ci-nix-flake-update.yml`
- Runs on weekly schedule + manual dispatch
- Runs:
  - `nix flake update`
  - detects whether `flake.lock` changed
  - `nix flake check --no-build` only if changed
  - `nix build .#default` only if changed
- Commits and pushes `flake.lock` back to `linux/rust` only if changed.
- Keeps PR automation block commented out (can switch between direct-commit and PR mode)

## Notes
- No-op runs do not commit anything.
- Commit happens only after update + check + build steps pass.