### PR TITLE
linux: clean up tray state when airpods disconnect during hibernation

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -423,22 +423,34 @@ public slots:
         LOG_INFO("System is waking up, starting ble scan");
         m_bleManager->startScan();
 
-        // Check if AirPods are already connected and activate A2DP profile
-        if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
-        {
-            LOG_INFO("AirPods already connected after wake-up, re-activating A2DP profile");
-            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
+        // Defer the BlueZ connection check: BlueZ may not have updated its
+        // Connected property yet at the moment PrepareForSleep(false) fires,
+        // and acting on a stale "disconnected" reading would cleanup a device
+        // that's actually still fine. A re-check after a short delay also
+        // gives BlueZ a chance to emit its own disconnect signal, which would
+        // run the normal cleanup path before we get here.
+        QTimer::singleShot(1500, this, [this]() {
+            bool stillConnected = monitor->checkAlreadyConnectedDevices();
+            bool hadConnection = m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty();
 
-            // Always activate A2DP profile after system wake since the profile might have been lost
-            QTimer::singleShot(1000, this, [this]()
+            if (stillConnected && hadConnection)
             {
-                mediaController->activateA2dpProfile();
-                LOG_INFO("A2DP profile activation attempted after system wake-up");
-            });
-        }
+                LOG_INFO("AirPods still connected after wake-up, re-activating A2DP profile");
+                mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
 
-        // Also check for already connected devices via BlueZ
-        monitor->checkAlreadyConnectedDevices();
+                // The A2DP profile may have been lost across the suspend cycle.
+                QTimer::singleShot(1000, this, [this]()
+                {
+                    mediaController->activateA2dpProfile();
+                    LOG_INFO("A2DP profile activation attempted after system wake-up");
+                });
+            }
+            else if (hadConnection)
+            {
+                LOG_INFO("AirPods not connected after wake-up, cleaning up stale state");
+                onDeviceDisconnected(QBluetoothAddress(m_deviceInfo->bluetoothAddress()));
+            }
+        });
     }
 
 private slots:

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -417,6 +417,25 @@ public slots:
             LOG_INFO("Stopping BLE scan before going to sleep");
             m_bleManager->stopScan();
         }
+
+        // Gracefully disconnect from the AirPods so they don't enter the
+        // aggressive "search for missing source" mode that drains the primary
+        // pod while the laptop is suspended. A hard radio kill (e.g. an
+        // rfkill-block sleep hook) leaves the link looking like a sudden
+        // out-of-range event to the pods; a clean L2CAP disconnect doesn't.
+        if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
+        {
+            const QString address = m_deviceInfo->bluetoothAddress();
+            LOG_INFO("Sending graceful disconnect to AirPods before sleep: " << address);
+            socket->close();
+
+            QProcess process;
+            process.start("bluetoothctl", QStringList() << "disconnect" << address);
+            // Bounded wait — we don't hold a logind inhibitor, so blocking
+            // here only delays our own slot, not the suspend itself.
+            process.waitForFinished(2000);
+            LOG_INFO("Bluetoothctl disconnect output: " << process.readAllStandardOutput().trimmed());
+        }
     }
     void onSystemWakingUp()
     {


### PR DESCRIPTION
The new Rust port is where this project is heading long-term, and I think that's a great direction. That said, I'm still using the Qt/C++ build day-to-day - it's the version I've come to rely on and personally prefer, so I'd love to keep it polished while the rewrite matures. Hope a small fix here is still welcome!

After waking from hibernation, the Linux app would leave the tray icon
stuck on the last battery percentage even when the AirPods were no longer
connected. The L2CAP socket state used by `onSystemWakingUp` is stale
across hibernation, and BlueZ may have torn down the connection without
the app seeing the `PropertiesChanged` signal.

What this PR does:

- Replaces the socket-level `areAirpodsConnected()` check with a deferred
  BlueZ query (`monitor->checkAlreadyConnectedDevices()`), which is
  authoritative.
- Wraps the check in a 1500 ms `QTimer::singleShot` so BlueZ's
  `Connected` property has time to settle after `PrepareForSleep(false)`
  and any pending `bluezDeviceDisconnected` signal can run the normal
  cleanup path first.
- Routes a stale-but-disconnected device through `onDeviceDisconnected`,
  which resets `DeviceInfo` and the tray icon.

## Test plan

- [x] Hibernate with AirPods connected, remove them from the case so they
  disconnect during sleep, then resume — tray icon resets to default,
  no stale battery %.
- [x] Hibernate with AirPods connected, leave them connected, then
  resume — A2DP profile is re-activated, tray keeps showing battery
  status, no false disconnect.
- [x] Tested on KDE Plasma 6 / Wayland.