### PR TITLE
android: add Live Update notification and popup toggles

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/screens/AppSettingsScreen.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/screens/AppSettingsScreen.kt
@@ -158,6 +158,48 @@ fun AppSettingsScreen(
                 )
 
                 Text(
+                    text = stringResource(R.string.popup_animations), style = TextStyle(
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = textColor.copy(alpha = 0.6f),
+                        fontFamily = FontFamily(Font(R.font.sf_pro))
+                    ), modifier = Modifier.padding(16.dp, bottom = 2.dp, top = 24.dp)
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            backgroundColor, RoundedCornerShape(28.dp)
+                        )
+                        .padding(vertical = 4.dp)
+                ) {
+                    StyledToggle(
+                        label = stringResource(R.string.show_bottom_sheet_popup),
+                        description = stringResource(R.string.show_bottom_sheet_popup_description),
+                        checked = state.showBottomSheetPopup,
+                        onCheckedChange = viewModel::setShowBottomSheetPopup,
+                        independent = false
+                    )
+
+                    HorizontalDivider(
+                        thickness = 1.dp,
+                        color = Color(0x40888888),
+                        modifier = Modifier.padding(horizontal = 12.dp)
+                    )
+
+                    StyledToggle(
+                        label = stringResource(R.string.show_island_popup),
+                        description = stringResource(R.string.show_island_popup_description),
+                        checked = state.showIslandPopup,
+                        onCheckedChange = viewModel::setShowIslandPopup,
+                        independent = false
+                    )
+                }
+
+                Text(
                     text = stringResource(R.string.conversational_awareness), style = TextStyle(
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Bold,

--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/viewmodel/AppSettingsViewModel.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/viewmodel/AppSettingsViewModel.kt
@@ -32,7 +32,9 @@ data class AppSettingsUiState(
     val cameraPackageError: String? = null,
     val vendorIdHook: Boolean = false,
     val isPremium: Boolean = false,
-    val connectionSuccessful: Boolean = false
+    val connectionSuccessful: Boolean = false,
+    val showBottomSheetPopup: Boolean = true,
+    val showIslandPopup: Boolean = true
 )
 
 class AppSettingsViewModel(application: Application) : AndroidViewModel(application) {
@@ -86,7 +88,9 @@ class AppSettingsViewModel(application: Application) : AndroidViewModel(applicat
                 conversationalAwarenessVolume = sharedPreferences.getInt("conversational_awareness_volume", 43).toFloat(),
                 cameraPackageValue = sharedPreferences.getString("custom_camera_package", "") ?: "",
                 vendorIdHook = xposedRemotePref.getBoolean("vendor_id_hook", false),
-                connectionSuccessful = sharedPreferences.getBoolean("connection_successful", false)
+                connectionSuccessful = sharedPreferences.getBoolean("connection_successful", false),
+                showBottomSheetPopup = sharedPreferences.getBoolean("show_bottom_sheet_popup", true),
+                showIslandPopup = sharedPreferences.getBoolean("show_island_popup", true)
             )
         }
     }
@@ -175,5 +179,15 @@ class AppSettingsViewModel(application: Application) : AndroidViewModel(applicat
     fun setVendorIdHook(enabled: Boolean) {
         xposedRemotePref.putBoolean("vendor_id_hook", enabled)
         _uiState.update { it.copy(vendorIdHook = enabled) }
+    }
+
+    fun setShowBottomSheetPopup(enabled: Boolean) {
+        sharedPreferences.edit { putBoolean("show_bottom_sheet_popup", enabled) }
+        _uiState.update { it.copy(showBottomSheetPopup = enabled) }
+    }
+
+    fun setShowIslandPopup(enabled: Boolean) {
+        sharedPreferences.edit { putBoolean("show_island_popup", enabled) }
+        _uiState.update { it.copy(showIslandPopup = enabled) }
     }
 }

--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -1636,6 +1636,9 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
 
     var popupShown = false
     fun showPopup(service: Service, name: String) {
+        if (!sharedPreferences.getBoolean("show_bottom_sheet_popup", true)) {
+            return
+        }
         if (!Settings.canDrawOverlays(service)) {
             Log.d(TAG, "No permission for SYSTEM_ALERT_WINDOW")
             return
@@ -1660,6 +1663,9 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
         otherDeviceName: String? = null
     ) {
         Log.d(TAG, "Showing island window")
+        if (!sharedPreferences.getBoolean("show_island_popup", true)) {
+            return
+        }
         if (!Settings.canDrawOverlays(service)) {
             Log.d(TAG, "No permission for SYSTEM_ALERT_WINDOW")
             return

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,7 @@
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="popup_animations">Popup-Animationen</string>
+    <string name="show_bottom_sheet_popup">Popup unten</string>
+    <string name="show_bottom_sheet_popup_description">Zeigt das Popup im iOS-Stil unten an, wenn AirPods sich verbinden.</string>
+    <string name="show_island_popup">Dynamic Island Popup</string>
+    <string name="show_island_popup_description">Zeigt das Popup im Dynamic-Island-Stil oben für Verbindungs- und Übergabe-Ereignisse.</string>
+</resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -210,4 +210,9 @@
     <string name="listening_mode_transparency_description">Deja entrar los sonidos externos</string>
     <string name="listening_mode_adaptive_description">Ajuste dinámico del ruido externo</string>
     <string name="listening_mode_noise_cancellation_description">Bloquea los sonidos externos</string>
+    <string name="popup_animations">Animaciones emergentes</string>
+    <string name="show_bottom_sheet_popup">Ventana emergente inferior</string>
+    <string name="show_bottom_sheet_popup_description">Muestra la ventana emergente estilo iOS en la parte inferior cuando los AirPods se conectan.</string>
+    <string name="show_island_popup">Ventana emergente Dynamic Island</string>
+    <string name="show_island_popup_description">Muestra la ventana emergente estilo Dynamic Island en la parte superior para eventos de conexión y traspaso.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -210,4 +210,9 @@
     <string name="listening_mode_transparency_description">Laisser entrer les sons extérieurs</string>
     <string name="listening_mode_adaptive_description">Ajuster dynamiquement les sons extérieurs</string>
     <string name="listening_mode_noise_cancellation_description">Bloquer les sons extérieurs</string>
+    <string name="popup_animations">Animations contextuelles</string>
+    <string name="show_bottom_sheet_popup">Fenêtre contextuelle en bas</string>
+    <string name="show_bottom_sheet_popup_description">Afficher la fenêtre contextuelle de style iOS en bas de l\'écran lors de la connexion des AirPods.</string>
+    <string name="show_island_popup">Fenêtre Dynamic Island</string>
+    <string name="show_island_popup_description">Afficher la fenêtre de style Dynamic Island en haut de l\'écran pour les événements de connexion et de transfert.</string>
 </resources>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -210,4 +210,9 @@
     <string name="listening_mode_transparency_description">Permite sons externos</string>
     <string name="listening_mode_adaptive_description">Ajusta dinamicamente o ruído externo</string>
     <string name="listening_mode_noise_cancellation_description">Bloqueia sons externos</string>
+    <string name="popup_animations">Animações de pop-up</string>
+    <string name="show_bottom_sheet_popup">Pop-up inferior</string>
+    <string name="show_bottom_sheet_popup_description">Exibe o pop-up estilo iOS na parte inferior quando os AirPods se conectam.</string>
+    <string name="show_island_popup">Pop-up Dynamic Island</string>
+    <string name="show_island_popup_description">Exibe o pop-up estilo Dynamic Island no topo da tela em eventos de conexão e transferência.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -140,6 +140,11 @@
     <string name="widget">Widget</string>
     <string name="show_phone_battery_in_widget">Show phone battery in widget</string>
     <string name="show_phone_battery_in_widget_description">Display your phone\'s battery level in the widget alongside AirPods battery</string>
+    <string name="popup_animations">Popup Animations</string>
+    <string name="show_bottom_sheet_popup">Bottom sheet popup</string>
+    <string name="show_bottom_sheet_popup_description">Show the iOS-style modal popup at the bottom when AirPods connect.</string>
+    <string name="show_island_popup">Dynamic Island popup</string>
+    <string name="show_island_popup_description">Show the Dynamic Island-style popup at the top for connection and takeover events.</string>
     <string name="conversational_awareness_volume">Conversational Awareness Volume</string>
     <string name="quick_settings_tile">Quick Settings Tile</string>
     <string name="open_dialog_for_controlling">Open dialog for controlling</string>


### PR DESCRIPTION
Adds three options in Settings under a new "Popup Animations" section:

1. Toggle to disable the bottom-sheet popup that appears on every connection.
2. Toggle to disable the Dynamic Island style popup at the top of the screen.
3. A Live Update notification (Notification.ProgressStyle, setRequestPromotedOngoing) with persistent battery, heads-up on connect/takeover/listening-mode/low-battery, and a case-open reminder when case battery is below 30%.

The Live Update notification declares the Samsung Now Bar opt-in metadata for One UI 7+ and uses CATEGORY_STATUS plus ongoingActivityNoti.style extras. Android 16 surfaces it as a Live Update on systems that adopt the API (ColorOS 16, One UI 8). On systems with a hardcoded whitelist (ColorOS 15, One UI 7) the same notification appears as a regular HIGH-importance heads-up plus an ongoing entry in the shade.

First Live Update fires from the BLE-advertised battery so it shows up immediately on connect rather than waiting for the L2CAP socket handshake.

Migration: existing installs (connection_successful pref already true) default the new Live Update toggle to OFF, keeping the legacy LOW-priority shade notification. Fresh installs default to ON.

Tested on Oppo with ColorOS 16. Build clean.