### PR TITLE
fix: sync magisk update json with current release URLs

### DIFF
--- a/extras/update_nonpatch.json
+++ b/extras/update_nonpatch.json
@@ -1,6 +1,6 @@
 {
   "version": "v0.2.6",
   "versionCode": 46,
-  "zipUrl": "https://github.com/kavishdevar/librepods/releases/download/v0.2.3/LibrePods-FOSS-v0.2.3-release.zip",
-  "changelog": "https://raw.githubusercontent.com/kavishdevar/librepods/main/CHANGELOG.md"
+  "zipUrl": "https://github.com/kavishdevar/librepods/releases/download/v0.2.6/LibrePods-FOSS-v0.2.6-release.zip",
+  "changelog": "https://raw.githubusercontent.com/kavishdevar/librepods/main/extras/CHANGELOG.md"
 }


### PR DESCRIPTION
The Magisk module reads its update info from \`extras/update_nonpatch.json\` (per \`updateJson\` in \`root-module-manual/module.prop\`). That file still points to the v0.2.3 zip and to a changelog path that no longer exists.

The duplicate \`update_nonpatch.json\` at the repo root was already updated to the v0.2.6 zip and the new changelog location, so this just brings the extras copy in line.

Fixes the symptom in #547 where Magisk repeatedly tries to "update" to v0.2.3.