### PR TITLE
android: allow non-premium users to disable head gestures

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/screens/HeadTrackingScreen.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/screens/HeadTrackingScreen.kt
@@ -197,7 +197,7 @@ fun HeadTrackingScreen(viewModel: AirPodsViewModel, navController: NavController
                     label = "Head Gestures",
                     checked = state.headGesturesEnabled,
                     onCheckedChange = { viewModel.setHeadGesturesEnabled(it) },
-                    enabled = state.isPremium,
+                    enabled = state.isPremium || state.headGesturesEnabled,
                     description = stringResource(R.string.head_gestures_details)
                 )
 


### PR DESCRIPTION
On HeadTrackingScreen the toggle uses \`enabled = state.isPremium\`, which makes it un-flippable for non-premium users. Combined with the default \`head_gestures = true\` set on first run (and previously enabled state for users who paired before the paywall), this leaves non-premium users unable to turn head gestures off. The runtime then keeps invoking the gesture detector on incoming calls, which is the symptom in #556 (calls being hung up by stray head movement).

Smallest fix: allow the toggle when the feature is currently on, even without premium. Non-premium users can flip it off; once off, they can't flip it back on without upgrading.

Doesn't change premium gating elsewhere (the runtime still uses the preference value as before; this just makes the off-switch reachable).

Closes #556