### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-android.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-android.yml
@@ -49,10 +49,8 @@ body:
       label: Root / hook method
       options:
         - No root (native L2CAP support)
-        - Magisk + Xposed (LSPosed)
-        - Magisk + btl2capfix
-        - KernelSU + Xposed (LSPosed)
-        - KernelSU + btl2capfix
+        - Magisk + Xposed
+        - KernelSU + Xposed
         - Other (describe in additional context)
     validations:
       required: true
@@ -91,9 +89,21 @@ body:
     attributes:
       label: Logs
       description: |
-        Open the app, go to `Settings → Troubleshooting → Collect Logs`, and attach the resulting file here.
-        Without logs most bugs are very hard to diagnose.
-      placeholder: Paste log content or attach `librepods-logs.txt`
+        If you are rooted, give the app root access, open the app, go to `Settings → Troubleshooting → Collect Logs`, and attach the resulting file here.
+        Without logs most bugs are very hard to diagnose. If you are not, follow these instructions:
+        
+        (Needs access to a computer, and USB/Wireless Debugging under developer options enabled)
+        Get the uid: Linux/Mac: `adb shell dumpsys package me.kavishdevar.librepods | grep uid`
+        Start logs: `adb logcat --uid=<uid>,1002 >> librepods-logs.txt` (1002 is for bluetooth)
+        
+        Steps for proper logs
+        - force close the app
+        - turn off bluetooth
+        - start logs
+        - open the app
+        - turn on bluetooth and connect
+
+      placeholder: Paste log content or attach the file
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/01-bug-report-android.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-android.yml
@@ -1,0 +1,101 @@
+name: Bug report (Android)
+description: Report a bug in the Android app
+labels: ["bug", "android"]
+title: "[Android] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much as you can.
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: "Find this in `Settings → About → Version` in the app, or in your phone's app info."
+      placeholder: "v0.2.5 (build 46)"
+    validations:
+      required: true
+  - type: dropdown
+    id: app-source
+    attributes:
+      label: App source
+      options:
+        - GitHub release (FOSS)
+        - Play Store
+        - Nightly build
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: Manufacturer and model.
+      placeholder: "Google Pixel 8 Pro"
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android / OS version
+      description: Include the OEM skin if relevant.
+      placeholder: "Android 16, OxygenOS 16, ColorOS 16, ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: root-method
+    attributes:
+      label: Root / hook method
+      options:
+        - No root (native L2CAP support)
+        - Magisk + Xposed (LSPosed)
+        - Magisk + btl2capfix
+        - KernelSU + Xposed (LSPosed)
+        - KernelSU + btl2capfix
+        - Other (describe in additional context)
+    validations:
+      required: true
+  - type: dropdown
+    id: airpods-model
+    attributes:
+      label: AirPods model
+      options:
+        - AirPods (1st gen)
+        - AirPods (2nd gen)
+        - AirPods (3rd gen)
+        - AirPods (4th gen)
+        - AirPods (4th gen) with ANC
+        - AirPods Pro (1st gen)
+        - AirPods Pro 2 (Lightning)
+        - AirPods Pro 2 (USB-C)
+        - AirPods Pro 3
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: firmware
+    attributes:
+      label: AirPods firmware
+      description: Find this under `About` in the app once connected.
+      placeholder: "8454768"
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened
+      description: Describe what you observed and what you expected. Include steps to reproduce if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Open the app, go to `Settings → Troubleshooting → Collect Logs`, and attach the resulting file here.
+        Without logs most bugs are very hard to diagnose.
+      placeholder: Paste log content or attach `librepods-logs.txt`
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that might help (screenshots, video, related issues, what you've already tried).

--- a/.github/ISSUE_TEMPLATE/02-bug-report-linux.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-report-linux.yml
@@ -1,0 +1,87 @@
+name: Bug report (Linux)
+description: Report a bug in the Linux client
+labels: ["bug", "linux"]
+title: "[Linux] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please fill in as much as you can.
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      placeholder: "linux-v0.1.0, or linux-rust commit abc1234"
+    validations:
+      required: true
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Client variant
+      options:
+        - linux-rust (Tauri)
+        - linux (Qt)
+        - Built from source
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: distro
+    attributes:
+      label: Distro and version
+      placeholder: "Arch Linux, Fedora 41, Ubuntu 24.04, NixOS 25.05"
+    validations:
+      required: true
+  - type: input
+    id: desktop
+    attributes:
+      label: Desktop environment / compositor
+      placeholder: "GNOME 47 (Wayland), KDE 6, Hyprland, ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - Built from source
+        - AUR
+        - Pre-built binary from releases
+        - AppImage
+        - Flatpak
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: airpods-model
+    attributes:
+      label: AirPods model
+      options:
+        - AirPods (1st gen)
+        - AirPods (2nd gen)
+        - AirPods (3rd gen)
+        - AirPods (4th gen)
+        - AirPods (4th gen) with ANC
+        - AirPods Pro (1st gen)
+        - AirPods Pro 2 (Lightning)
+        - AirPods Pro 2 (USB-C)
+        - AirPods Pro 3
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened
+      description: Describe what you observed and what you expected. Include steps to reproduce if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and stderr
+      description: Run the app from a terminal and paste any output. Include relevant `journalctl --user -e` snippets if there is a crash.
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/02-bug-report-linux.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-report-linux.yml
@@ -1,5 +1,5 @@
 name: Bug report (Linux)
-description: Report a bug in the Linux client
+description: Report a bug in the Linux program
 labels: ["bug", "linux"]
 title: "[Linux] "
 body:
@@ -17,12 +17,10 @@ body:
   - type: dropdown
     id: variant
     attributes:
-      label: Client variant
+      label: Variant
       options:
-        - linux-rust (Tauri)
-        - linux (Qt)
-        - Built from source
-        - Not sure
+        - Rust rewrite (`linux-rust` branch)
+        - QT version (NOT MAINTAINED! issues will be closed)
     validations:
       required: true
   - type: input
@@ -36,19 +34,17 @@ body:
     id: desktop
     attributes:
       label: Desktop environment / compositor
-      placeholder: "GNOME 47 (Wayland), KDE 6, Hyprland, ..."
+      placeholder: "GNOME 47 (Wayland), KDE 6 (X11), Hyprland, ..."
     validations:
       required: true
   - type: dropdown
     id: install-method
     attributes:
-      label: Install method
+      label: Install method (only official sources)
       options:
-        - Built from source
-        - AUR
-        - Pre-built binary from releases
+        - Built from source (`nix` or otherwise)
+        - Pre-built binary
         - AppImage
-        - Flatpak
         - Other
     validations:
       required: true
@@ -80,7 +76,7 @@ body:
     id: logs
     attributes:
       label: Logs and stderr
-      description: Run the app from a terminal and paste any output. Include relevant `journalctl --user -e` snippets if there is a crash.
+      description: Run the app from a terminal with `--debug` and paste the output.
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Android
+        - Linux
+        - Both
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do? What is missing or hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How might it work? UI sketches, behavior, edge cases.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered


### PR DESCRIPTION
Adds three GitHub issue forms under \`.github/ISSUE_TEMPLATE/\`:

- Android bug report
- Linux bug report
- Feature request

Each form prompts for the things you usually have to ask for (app version, app source, device, OS, root method, AirPods model, firmware, logs). The Android template links to \`Settings → Troubleshooting → Collect Logs\` for the log step, and pre-applies \`bug,android\` / \`bug,linux\` labels.

No \`config.yml\`, so blank issues stay enabled (the templates appear as choices, not as a forced gate).

Addresses the issue template part of #350. The compatibility matrix and a separate logs guide from that issue are not in this PR.