### PR TITLE
android: avoid double sendPause when both AirPods are removed at once

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/services/AirPodsService.kt
@@ -1286,7 +1286,8 @@ class AirPodsService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                         MediaController.sendPlay()
                         MediaController.iPausedTheMedia = false
                     }
-                } else {
+                } else if (newInEarData != listOf(false, false)) {
+                    // The "both removed" case is already handled by the sendPause(force=true) branch above.
                     MediaController.sendPause()
                 }
             }


### PR DESCRIPTION
When both ear detection bits flip from in to out in one packet, sendPause gets called twice. Once with force=true in the upper branch, then again at the bottom block. The second call is usually a no-op since music is already paused, but a timing race is possible.

This might affect #153, but no idea as i cant seem to reproduce it. Its a code cleanup atleast.