### PR TITLE
fix: head gesture detection biased toward 'yes' (#555)

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/GestureDetector.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/GestureDetector.kt
@@ -367,33 +367,28 @@ fun startDetection(doNotStop: Boolean = false, onGestureDetected: (Boolean) -> U
         val requiredExtremes = getRequiredExtremes()
         Log.d(TAG, "Current required extremes: $requiredExtremes")
 
-        if (verticalPeaks.size + verticalTroughs.size >= requiredExtremes) {
+        val verticalConfidence = if (verticalPeaks.size + verticalTroughs.size >= requiredExtremes) {
             val allExtremes = (verticalPeaks + verticalTroughs).sortedBy { it.first }
+            calculateConfidenceScore(allExtremes, isVertical = true)
+        } else 0.0
 
-            val confidence = calculateConfidenceScore(allExtremes, isVertical = true)
-
-            Log.d(TAG, "Vertical motion confidence: $confidence (need $minConfidenceThreshold)")
-
-            if (confidence >= minConfidenceThreshold) {
-                Log.d(TAG, "\"Yes\" Gesture Detected (confidence: $confidence, extremes: ${allExtremes.size}/$requiredExtremes)")
-                return true
-            }
-        }
-
-        if (horizontalPeaks.size + horizontalTroughs.size >= requiredExtremes) {
+        val horizontalConfidence = if (horizontalPeaks.size + horizontalTroughs.size >= requiredExtremes) {
             val allExtremes = (horizontalPeaks + horizontalTroughs).sortedBy { it.first }
+            calculateConfidenceScore(allExtremes, isVertical = false)
+        } else 0.0
 
-            val confidence = calculateConfidenceScore(allExtremes, isVertical = false)
+        Log.d(TAG, "Confidence: vertical=$verticalConfidence horizontal=$horizontalConfidence (need $minConfidenceThreshold)")
 
-            Log.d(TAG, "Horizontal motion confidence: $confidence (need $minConfidenceThreshold)")
+        val maxConfidence = max(verticalConfidence, horizontalConfidence)
+        if (maxConfidence < minConfidenceThreshold) return null
 
-            if (confidence >= minConfidenceThreshold) {
-                Log.d(TAG, "\"No\" Gesture Detected (confidence: $confidence, extremes: ${allExtremes.size}/$requiredExtremes)")
-                return false
-            }
+        return if (verticalConfidence >= horizontalConfidence) {
+            Log.d(TAG, "\"Yes\" Gesture Detected (vertical=$verticalConfidence, horizontal=$horizontalConfidence)")
+            true
+        } else {
+            Log.d(TAG, "\"No\" Gesture Detected (vertical=$verticalConfidence, horizontal=$horizontalConfidence)")
+            false
         }
-
-        return null
     }
 
     private fun clearData() {


### PR DESCRIPTION
closes #555

## the problem

old detectGestures() checked vertical first. if vertical extremes (peaks+troughs) reached the required count and confidence passed the threshold, it returned "yes" immediately, never even computing horizontal confidence. only if vertical didnt reach the count OR didnt pass the threshold did it look at horizontal.

so any motion that bled into the vertical buffer enough to clear the threshold won, even if the horizontal motion was clearly stronger. simplest repro: look slightly down and shake your head. natural neck biomechanics couple yaw with a bit of pitch wobble, the wobble accumulates enough vertical extremes to pass, "yes detected" even though the user is shaking "no".

## the fix

compute both confidences, take the higher one. only emit a gesture if the higher confidence is above the threshold, and pick the direction (yes/no) based on which side won.

```
val maxConfidence = max(verticalConfidence, horizontalConfidence)
if (maxConfidence < minConfidenceThreshold) return null
return verticalConfidence >= horizontalConfidence
```

isolationFactor inside calculateConfidenceScore already penalises bleed (vertical amplitude vs horizontal amplitude and vice versa), so when motion is dominantly horizontal, the horizontal score outpaces the vertical score even if both pass the count threshold.

## what this does NOT fix

if you're at extreme poses where the bleed dominates (headstand, lying on side and nodding), you can theoretically still confuse it. but the data going into the detector is already head-relative angular rates, so the ear-axis is the ear-axis no matter how youre oriented. couldnt repro at any normal pose, would need actual headstand testing to find a real failure case. left out of this PR.

## test

repro on old build: tilt head down, shake → "yes" fires. on this branch the same motion correctly fires "no" (or nothing if the confidence is too low). couldnt find any case where a real "yes" nod gets misread as "no" with the new logic.