### PR TITLE
made some changes to get airpods 4 (anc) support and connect/disconnect buttons added to ui (linux)

### DIFF
--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -258,7 +258,6 @@ ApplicationWindow {
                     Column {
                         visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
                         spacing: 5
-                        width: parent.width
 
                         Label {
                             text: qsTr("Press & Hold Noise Modes:")
@@ -311,7 +310,6 @@ ApplicationWindow {
                     Column {
                         visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
                         spacing: 5
-                        width: parent.width
 
                         Label {
                             text: qsTr("Long Press Action:")

--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -77,7 +77,6 @@ ApplicationWindow {
                     radius: 12
                     color: airPodsTrayApp.airpodsConnected ? "#30D158" : "#FF453A"
                     opacity: 0.8
-                    visible: !airPodsTrayApp.airpodsConnected
 
                     Label {
                         anchors.centerIn: parent
@@ -85,6 +84,24 @@ ApplicationWindow {
                         color: "white"
                         font.pixelSize: 12
                         font.weight: Font.Medium
+                    }
+                }
+
+                // Connect / Disconnect buttons
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: 10
+
+                    Button {
+                        text: qsTr("Connect")
+                        visible: !airPodsTrayApp.airpodsConnected
+                        onClicked: airPodsTrayApp.userConnect()
+                    }
+
+                    Button {
+                        text: qsTr("Disconnect")
+                        visible: airPodsTrayApp.airpodsConnected
+                        onClicked: airPodsTrayApp.userDisconnect()
                     }
                 }
 

--- a/linux/Main.qml
+++ b/linux/Main.qml
@@ -133,11 +133,11 @@ ApplicationWindow {
                     model: [qsTr("Off"), qsTr("Noise Cancellation"), qsTr("Transparency"), qsTr("Adaptive")]
                     currentIndex: airPodsTrayApp.deviceInfo.noiseControlMode
                     onCurrentIndexChanged: airPodsTrayApp.setNoiseControlModeInt(currentIndex)
-                    visible: airPodsTrayApp.airpodsConnected
+                    visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
                 }
 
                 Slider {
-                    visible: airPodsTrayApp.deviceInfo.adaptiveModeActive
+                    visible: airPodsTrayApp.deviceInfo.adaptiveModeActive && airPodsTrayApp.deviceInfo.hasAdaptive
                     from: 0
                     to: 100
                     stepSize: 1
@@ -159,7 +159,7 @@ ApplicationWindow {
                 }
 
                 Switch {
-                    visible: airPodsTrayApp.airpodsConnected
+                    visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
                     text: qsTr("Conversational Awareness")
                     checked: airPodsTrayApp.deviceInfo.conversationalAwareness
                     onCheckedChanged: airPodsTrayApp.setConversationalAwareness(checked)
@@ -242,15 +242,114 @@ ApplicationWindow {
                     }
 
                     Switch {
-                        visible: airPodsTrayApp.airpodsConnected
+                        visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
                         text: qsTr("One Bud ANC Mode")
                         checked: airPodsTrayApp.deviceInfo.oneBudANCMode
-                        onCheckedChanged: airPodsTrayApp.deviceInfo.oneBudANCMode = checked
+                        onCheckedChanged: airPodsTrayApp.setOneBudANCMode(checked)
 
                         ToolTip {
                             visible: parent.hovered
                             text: qsTr("Enable ANC when using one AirPod\n(More noise reduction, but uses more battery)")
                             delay: 500
+                        }
+                    }
+
+                    // Listening Mode Cycle Configuration
+                    Column {
+                        visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
+                        spacing: 5
+                        width: parent.width
+
+                        Label {
+                            text: qsTr("Press & Hold Noise Modes:")
+                            font.bold: true
+                        }
+
+                        CheckBox {
+                            text: qsTr("Off")
+                            checked: (airPodsTrayApp.deviceInfo.listeningModeConfig & 1) !== 0
+                            onClicked: {
+                                var mask = airPodsTrayApp.deviceInfo.listeningModeConfig;
+                                if (checked) mask |= 1; else mask &= ~1;
+                                airPodsTrayApp.applyListeningModeConfig(mask);
+                            }
+                        }
+
+                        CheckBox {
+                            text: qsTr("Noise Cancellation")
+                            checked: (airPodsTrayApp.deviceInfo.listeningModeConfig & 2) !== 0
+                            onClicked: {
+                                var mask = airPodsTrayApp.deviceInfo.listeningModeConfig;
+                                if (checked) mask |= 2; else mask &= ~2;
+                                airPodsTrayApp.applyListeningModeConfig(mask);
+                            }
+                        }
+
+                        CheckBox {
+                            text: qsTr("Transparency")
+                            checked: (airPodsTrayApp.deviceInfo.listeningModeConfig & 4) !== 0
+                            onClicked: {
+                                var mask = airPodsTrayApp.deviceInfo.listeningModeConfig;
+                                if (checked) mask |= 4; else mask &= ~4;
+                                airPodsTrayApp.applyListeningModeConfig(mask);
+                            }
+                        }
+
+                        CheckBox {
+                            visible: airPodsTrayApp.deviceInfo.hasAdaptive
+                            text: qsTr("Adaptive Transparency")
+                            checked: (airPodsTrayApp.deviceInfo.listeningModeConfig & 8) !== 0
+                            onClicked: {
+                                var mask = airPodsTrayApp.deviceInfo.listeningModeConfig;
+                                if (checked) mask |= 8; else mask &= ~8;
+                                airPodsTrayApp.applyListeningModeConfig(mask);
+                            }
+                        }
+                    }
+
+                    // Click-Hold Mode (per bud: Noise Control or Siri)
+                    Column {
+                        visible: airPodsTrayApp.airpodsConnected && airPodsTrayApp.deviceInfo.hasANC
+                        spacing: 5
+                        width: parent.width
+
+                        Label {
+                            text: qsTr("Long Press Action:")
+                            font.bold: true
+                        }
+
+                        Row {
+                            spacing: 10
+
+                            Label {
+                                text: qsTr("Right:")
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            ComboBox {
+                                model: [qsTr("Noise Control"), qsTr("Siri")]
+                                currentIndex: airPodsTrayApp.deviceInfo.clickHoldModeRight === 5 ? 1 : 0
+                                onActivated: {
+                                    var val = currentIndex === 1 ? 5 : 1;
+                                    airPodsTrayApp.applyClickHoldMode(val, airPodsTrayApp.deviceInfo.clickHoldModeLeft);
+                                }
+                            }
+                        }
+
+                        Row {
+                            spacing: 10
+
+                            Label {
+                                text: qsTr("Left:")
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            ComboBox {
+                                model: [qsTr("Noise Control"), qsTr("Siri")]
+                                currentIndex: airPodsTrayApp.deviceInfo.clickHoldModeLeft === 5 ? 1 : 0
+                                onActivated: {
+                                    var val = currentIndex === 1 ? 5 : 1;
+                                    airPodsTrayApp.applyClickHoldMode(airPodsTrayApp.deviceInfo.clickHoldModeRight, val);
+                                }
+                            }
                         }
                     }
 

--- a/linux/airpods_packets.h
+++ b/linux/airpods_packets.h
@@ -145,6 +145,38 @@ namespace AirPodsPackets
         inline std::optional<bool> parseState(const QByteArray &data) { return Type::parseState(data); }
     }
 
+    // Listening Mode Configs — configures which modes the stem long press cycles through
+    // Bitmask: Off=0x01, ANC=0x02, Transparency=0x04, Adaptive=0x08
+    namespace ListeningModeConfigs
+    {
+        static const QByteArray HEADER = ControlCommand::HEADER + static_cast<char>(0x1A);
+
+        static QByteArray getPacket(quint8 configBitmask)
+        {
+            return ControlCommand::createCommand(0x1A, configBitmask);
+        }
+
+        inline std::optional<quint8> parseConfig(const QByteArray &data)
+        {
+            auto val = ControlCommand::parseActive(data);
+            if (val) return static_cast<quint8>(val.value());
+            return std::nullopt;
+        }
+    }
+
+    // Click Hold Mode — what the stem long press does per bud
+    // data1 = right bud, data2 = left bud
+    // Values: 0x01 = Noise Control, 0x05 = Siri
+    namespace ClickHoldMode
+    {
+        static const QByteArray HEADER = ControlCommand::HEADER + static_cast<char>(0x16);
+
+        static QByteArray getPacket(quint8 rightBud, quint8 leftBud)
+        {
+            return ControlCommand::createCommand(0x16, rightBud, leftBud);
+        }
+    }
+
     // Connection Packets
     namespace Connection
     {

--- a/linux/deviceinfo.hpp
+++ b/linux/deviceinfo.hpp
@@ -29,6 +29,11 @@ class DeviceInfo : public QObject
     Q_PROPERTY(QString bluetoothAddress READ bluetoothAddress WRITE setBluetoothAddress NOTIFY bluetoothAddressChanged)
     Q_PROPERTY(QString magicAccIRK READ magicAccIRKHex CONSTANT)
     Q_PROPERTY(QString magicAccEncKey READ magicAccEncKeyHex CONSTANT)
+    Q_PROPERTY(int listeningModeConfig READ listeningModeConfig WRITE setListeningModeConfig NOTIFY listeningModeConfigChanged)
+    Q_PROPERTY(bool hasANC READ hasANC NOTIFY modelChanged)
+    Q_PROPERTY(bool hasAdaptive READ hasAdaptive NOTIFY modelChanged)
+    Q_PROPERTY(int clickHoldModeRight READ clickHoldModeRight WRITE setClickHoldModeRight NOTIFY clickHoldModeChanged)
+    Q_PROPERTY(int clickHoldModeLeft READ clickHoldModeLeft WRITE setClickHoldModeLeft NOTIFY clickHoldModeChanged)
 
 public:
     explicit DeviceInfo(QObject *parent = nullptr) : QObject(parent), m_battery(new Battery(this)), m_earDetection(new EarDetection(this)) {
@@ -120,6 +125,41 @@ public:
         }
     }
 
+    // Model capability flags
+    bool hasANC() const { return modelHasANC(m_model); }
+    bool hasAdaptive() const { return modelHasAdaptive(m_model); }
+
+    // Listening mode config (bitmask: Off=0x01, ANC=0x02, Transparency=0x04, Adaptive=0x08)
+    int listeningModeConfig() const { return m_listeningModeConfig; }
+    void setListeningModeConfig(int config)
+    {
+        if (m_listeningModeConfig != config)
+        {
+            m_listeningModeConfig = config;
+            emit listeningModeConfigChanged(config);
+        }
+    }
+
+    // Click-hold mode per bud (0x01 = Noise Control, 0x05 = Siri)
+    int clickHoldModeRight() const { return m_clickHoldModeRight; }
+    void setClickHoldModeRight(int mode)
+    {
+        if (m_clickHoldModeRight != mode)
+        {
+            m_clickHoldModeRight = mode;
+            emit clickHoldModeChanged();
+        }
+    }
+    int clickHoldModeLeft() const { return m_clickHoldModeLeft; }
+    void setClickHoldModeLeft(int mode)
+    {
+        if (m_clickHoldModeLeft != mode)
+        {
+            m_clickHoldModeLeft = mode;
+            emit clickHoldModeChanged();
+        }
+    }
+
     QByteArray magicAccIRK() const { return m_magicAccIRK; }
     void setMagicAccIRK(const QByteArray &irk) { m_magicAccIRK = irk; }
     QString magicAccIRKHex() const { return QString::fromUtf8(m_magicAccIRK.toHex()); }
@@ -171,6 +211,7 @@ public:
         setBluetoothAddress("");
         getEarDetection()->reset();
         setHearingAidEnabled(false);
+        // Don't reset listeningModeConfig or clickHoldMode — we want to resend them on reconnect
     }
 
     void saveToSettings(QSettings &settings)
@@ -181,6 +222,9 @@ public:
         settings.setValue("magicAccIRK", magicAccIRK());
         settings.setValue("magicAccEncKey", magicAccEncKey());
         settings.setValue("hearingAidEnabled", hearingAidEnabled());
+        settings.setValue("listeningModeConfig", listeningModeConfig());
+        settings.setValue("clickHoldModeRight", clickHoldModeRight());
+        settings.setValue("clickHoldModeLeft", clickHoldModeLeft());
         settings.endGroup();
     }
     void loadFromSettings(const QSettings &settings)
@@ -190,6 +234,9 @@ public:
         setMagicAccIRK(settings.value("DeviceInfo/magicAccIRK", QByteArray()).toByteArray());
         setMagicAccEncKey(settings.value("DeviceInfo/magicAccEncKey", QByteArray()).toByteArray());
         setHearingAidEnabled(settings.value("DeviceInfo/hearingAidEnabled", false).toBool());
+        setListeningModeConfig(settings.value("DeviceInfo/listeningModeConfig", 0x0E).toInt());
+        setClickHoldModeRight(settings.value("DeviceInfo/clickHoldModeRight", 0x01).toInt());
+        setClickHoldModeLeft(settings.value("DeviceInfo/clickHoldModeLeft", 0x01).toInt());
     }
 
     void updateBatteryStatus()
@@ -217,6 +264,8 @@ signals:
     void oneBudANCModeChanged(bool enabled);
     void modelChanged();
     void bluetoothAddressChanged(const QString &address);
+    void listeningModeConfigChanged(int config);
+    void clickHoldModeChanged();
 
 private:
     QString m_batteryStatus;
@@ -234,4 +283,7 @@ private:
     QString m_manufacturer;
     QString m_bluetoothAddress;
     EarDetection *m_earDetection;
+    int m_listeningModeConfig = 0x0E; // Default: ANC + Transparency + Adaptive (no Off)
+    int m_clickHoldModeRight = 0x01;  // Default: Noise Control
+    int m_clickHoldModeLeft = 0x01;   // Default: Noise Control
 };

--- a/linux/enums.h
+++ b/linux/enums.h
@@ -103,5 +103,33 @@ namespace AirpodsTrayApp
             }
         }
 
+        // Returns true if the model supports Active Noise Cancellation
+        inline bool modelHasANC(AirPodsModel model) {
+            switch (model) {
+                case AirPodsModel::AirPods4ANC:
+                case AirPodsModel::AirPodsPro:
+                case AirPodsModel::AirPodsPro2Lightning:
+                case AirPodsModel::AirPodsPro2USBC:
+                case AirPodsModel::AirPodsMaxLightning:
+                case AirPodsModel::AirPodsMaxUSBC:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        // Returns true if the model supports Adaptive Transparency
+        inline bool modelHasAdaptive(AirPodsModel model) {
+            switch (model) {
+                case AirPodsModel::AirPods4ANC:
+                case AirPodsModel::AirPodsPro2Lightning:
+                case AirPodsModel::AirPodsPro2USBC:
+                case AirPodsModel::AirPodsMaxUSBC:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
     }
 }

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -253,15 +253,11 @@ public slots:
 
         LOG_INFO("Applying listening mode config: 0x" << QString::number(bitmask, 16));
 
-        // Send ListeningModeConfigs packet (0x1A)
+        // Send only ListeningModeConfigs packet (0x1A)
+        // AllowOffOption (0x34) is firmware-managed read-only state;
+        // the AirPods derive it from the 0x1A bitmask automatically.
         QByteArray configPacket = AirPodsPackets::ListeningModeConfigs::getPacket(static_cast<quint8>(bitmask));
         writePacketToSocket(configPacket, "Listening mode config packet written: ");
-
-        // Send AllowOffOption packet (0x34) — always sent atomically with 0x1A
-        bool offEnabled = (bitmask & 0x01) != 0;
-        QByteArray offPacket = offEnabled ? AirPodsPackets::AllowOffOption::ENABLED
-                                          : AirPodsPackets::AllowOffOption::DISABLED;
-        writePacketToSocket(offPacket, "Allow off option packet written: ");
 
         // Update DeviceInfo and persist
         m_deviceInfo->setListeningModeConfig(bitmask);

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -180,18 +180,31 @@ private:
 public slots:
     Q_INVOKABLE void userConnect() {
         LOG_INFO("User-initiated connect");
-        connectToAirPods(true);
+        if (!m_lastKnownAddress.isEmpty()) {
+            LOG_INFO("Reconnecting to last known address: " << m_lastKnownAddress);
+            QProcess process;
+            process.start("bluetoothctl", QStringList() << "connect" << m_lastKnownAddress);
+            process.waitForFinished(5000);
+            LOG_INFO("Bluetoothctl connect: " << process.readAllStandardOutput().trimmed());
+            // After bluetoothctl connects, the BLE monitor will pick it up automatically
+        } else {
+            connectToAirPods(true);
+        }
     }
 
     Q_INVOKABLE void userDisconnect() {
         LOG_INFO("User-initiated disconnect");
+        // Save address before reset
+        if (!m_deviceInfo->bluetoothAddress().isEmpty()) {
+            m_lastKnownAddress = m_deviceInfo->bluetoothAddress();
+        }
         if (socket && socket->isOpen()) {
             socket->close();
             LOG_INFO("Socket closed");
         }
-        if (!m_deviceInfo->bluetoothAddress().isEmpty()) {
+        if (!m_lastKnownAddress.isEmpty()) {
             QProcess process;
-            process.start("bluetoothctl", QStringList() << "disconnect" << m_deviceInfo->bluetoothAddress());
+            process.start("bluetoothctl", QStringList() << "disconnect" << m_lastKnownAddress);
             process.waitForFinished(3000);
             LOG_INFO("Bluetoothctl disconnect: " << process.readAllStandardOutput().trimmed());
         }
@@ -1050,6 +1063,7 @@ signals:
 
 private:
     QBluetoothSocket *socket = nullptr;
+    QString m_lastKnownAddress;
     QBluetoothSocket *phoneSocket = nullptr;
     QByteArray lastBatteryStatus;
     QByteArray lastEarDetectionStatus;

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -787,19 +787,6 @@ private slots:
             }
             m_bleManager->stopScan();
             emit airPodsStatusChanged();
-
-            // Resend saved listening mode config and click-hold mode on reconnect
-            int savedConfig = m_deviceInfo->listeningModeConfig();
-            int savedRight = m_deviceInfo->clickHoldModeRight();
-            int savedLeft = m_deviceInfo->clickHoldModeLeft();
-            QTimer::singleShot(500, this, [this, savedConfig, savedRight, savedLeft]() {
-                if (savedConfig > 0) {
-                    applyListeningModeConfig(savedConfig);
-                }
-                if (savedRight > 0 || savedLeft > 0) {
-                    applyClickHoldMode(savedRight, savedLeft);
-                }
-            });
         }
         else if (data.startsWith(AirPodsPackets::OneBudANCMode::HEADER)) {
             if (auto value = AirPodsPackets::OneBudANCMode::parseState(data))

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -238,6 +238,48 @@ public slots:
         }
     }
 
+    void applyListeningModeConfig(int bitmask)
+    {
+        // Ensure at least 2 modes are selected (need at least 2 to cycle)
+        int modeCount = 0;
+        for (int i = 0; i < 4; i++) {
+            if (bitmask & (1 << i)) modeCount++;
+        }
+        if (modeCount < 2)
+        {
+            LOG_WARN("Listening mode config must have at least 2 modes selected");
+            return;
+        }
+
+        LOG_INFO("Applying listening mode config: 0x" << QString::number(bitmask, 16));
+
+        // Send ListeningModeConfigs packet (0x1A)
+        QByteArray configPacket = AirPodsPackets::ListeningModeConfigs::getPacket(static_cast<quint8>(bitmask));
+        writePacketToSocket(configPacket, "Listening mode config packet written: ");
+
+        // Send AllowOffOption packet (0x34) — always sent atomically with 0x1A
+        bool offEnabled = (bitmask & 0x01) != 0;
+        QByteArray offPacket = offEnabled ? AirPodsPackets::AllowOffOption::ENABLED
+                                          : AirPodsPackets::AllowOffOption::DISABLED;
+        writePacketToSocket(offPacket, "Allow off option packet written: ");
+
+        // Update DeviceInfo and persist
+        m_deviceInfo->setListeningModeConfig(bitmask);
+        m_deviceInfo->saveToSettings(*m_settings);
+    }
+
+    void applyClickHoldMode(int rightBud, int leftBud)
+    {
+        LOG_INFO("Applying click-hold mode: right=" << rightBud << " left=" << leftBud);
+        QByteArray packet = AirPodsPackets::ClickHoldMode::getPacket(
+            static_cast<quint8>(rightBud), static_cast<quint8>(leftBud));
+        writePacketToSocket(packet, "Click-hold mode packet written: ");
+
+        m_deviceInfo->setClickHoldModeRight(rightBud);
+        m_deviceInfo->setClickHoldModeLeft(leftBud);
+        m_deviceInfo->saveToSettings(*m_settings);
+    }
+
     void setRetryAttempts(int attempts)
     {
         if (m_retryAttempts != attempts)
@@ -745,12 +787,43 @@ private slots:
             }
             m_bleManager->stopScan();
             emit airPodsStatusChanged();
+
+            // Resend saved listening mode config and click-hold mode on reconnect
+            int savedConfig = m_deviceInfo->listeningModeConfig();
+            int savedRight = m_deviceInfo->clickHoldModeRight();
+            int savedLeft = m_deviceInfo->clickHoldModeLeft();
+            QTimer::singleShot(500, this, [this, savedConfig, savedRight, savedLeft]() {
+                if (savedConfig > 0) {
+                    applyListeningModeConfig(savedConfig);
+                }
+                if (savedRight > 0 || savedLeft > 0) {
+                    applyClickHoldMode(savedRight, savedLeft);
+                }
+            });
         }
         else if (data.startsWith(AirPodsPackets::OneBudANCMode::HEADER)) {
             if (auto value = AirPodsPackets::OneBudANCMode::parseState(data))
             {
                 m_deviceInfo->setOneBudANCMode(value.value());
                 LOG_INFO("One Bud ANC mode received: " << m_deviceInfo->oneBudANCMode());
+            }
+        }
+        // Listening Mode Configs (0x1A) — stem long press cycle bitmask
+        else if (data.size() == 11 && data.startsWith(AirPodsPackets::ListeningModeConfigs::HEADER))
+        {
+            if (auto value = AirPodsPackets::ListeningModeConfigs::parseConfig(data))
+            {
+                m_deviceInfo->setListeningModeConfig(value.value());
+                m_deviceInfo->saveToSettings(*m_settings);
+                LOG_INFO("Listening mode config received: 0x" << QString::number(value.value(), 16));
+            }
+        }
+        // Allow Off Option (0x34)
+        else if (data.startsWith(AirPodsPackets::AllowOffOption::HEADER))
+        {
+            if (auto value = AirPodsPackets::AllowOffOption::parseState(data))
+            {
+                LOG_INFO("Allow off option received: " << value.value());
             }
         }
         else

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -178,6 +178,28 @@ private:
     }
 
 public slots:
+    Q_INVOKABLE void userConnect() {
+        LOG_INFO("User-initiated connect");
+        connectToAirPods(true);
+    }
+
+    Q_INVOKABLE void userDisconnect() {
+        LOG_INFO("User-initiated disconnect");
+        if (socket && socket->isOpen()) {
+            socket->close();
+            LOG_INFO("Socket closed");
+        }
+        if (!m_deviceInfo->bluetoothAddress().isEmpty()) {
+            QProcess process;
+            process.start("bluetoothctl", QStringList() << "disconnect" << m_deviceInfo->bluetoothAddress());
+            process.waitForFinished(3000);
+            LOG_INFO("Bluetoothctl disconnect: " << process.readAllStandardOutput().trimmed());
+        }
+        m_deviceInfo->reset();
+        emit airPodsStatusChanged();
+    }
+
+public slots:
     void connectToDevice(const QString &address) {
         LOG_INFO("Connecting to device with address: " << address);
         QBluetoothAddress btAddress(address);

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -94,6 +94,9 @@ public:
         monitor->checkAlreadyConnectedDevices();
         LOG_INFO("AirPodsTrayApp initialized");
 
+        // Load last known BT address for reconnect button
+        m_lastKnownAddress = m_settings->value("lastKnownAddress", "").toString();
+
         QBluetoothLocalDevice localDevice;
 
         const QList<QBluetoothAddress> connectedDevices = localDevice.connectedDevices();
@@ -197,6 +200,7 @@ public slots:
         // Save address before reset
         if (!m_deviceInfo->bluetoothAddress().isEmpty()) {
             m_lastKnownAddress = m_deviceInfo->bluetoothAddress();
+            m_settings->setValue("lastKnownAddress", m_lastKnownAddress);
         }
         if (socket && socket->isOpen()) {
             socket->close();
@@ -729,6 +733,8 @@ private slots:
 
         localSocket->connectToService(device.address(), QBluetoothUuid("74ec2172-0bad-4d01-8f77-997b2be0722a"));
         m_deviceInfo->setBluetoothAddress(device.address().toString());
+        m_lastKnownAddress = device.address().toString();
+        m_settings->setValue("lastKnownAddress", m_lastKnownAddress);
         notifyAndroidDevice();
     }
 

--- a/post-login-setup.sh
+++ b/post-login-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run this after logging back in to activate everything
+
+# Restart pipewire/wireplumber for new Bluetooth config
+systemctl --user restart wireplumber.service
+systemctl --user restart pipewire.service
+
+echo "Done! Connect your AirPods 4 via Bluetooth and run the librepods app."
+echo "Binary location: ~/Desktop/librepods/librepods/linux/build/librepods"


### PR DESCRIPTION
so i made some changes to librepods to get my airpods 4 (anc) working and some other tweaks like buttons to change the hold action modes and also a disconnect and conect button.

the main things in this pr:

* added airpods 4 anc detection so the ui shows the right stuff
* added settings to change what the stem press-and-hold cycles through (off/anc/transparency/adaptive)
* ability to change the long press action per earbud (noise control vs siri)
* added connect and disconnect buttons right on the main page so its easier to reconnect

ik its not perfect, i just used majority ai for help because i dont have much experience in kotlin and c++ etc etc and i dont expect this to be merged but i would be thankful if you take a look at it.

also goodluck to the JEE advanced exams! (im in class9 btw)

<img width="656" height="587" alt="image" src="https://github.com/user-attachments/assets/a312d3df-2cdd-48c4-ae19-ba584139c069" />
<img width="656" height="587" alt="image" src="https://github.com/user-attachments/assets/dea9f82c-ca70-4b83-90e2-7eb532abc001" />
