### PR TITLE
linux: pick a Quick Controls style before loading QML

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,7 +4,7 @@ project(linux VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Quick Widgets Bluetooth DBus LinguistTools)
+find_package(Qt6 REQUIRED COMPONENTS Quick QuickControls2 Widgets Bluetooth DBus LinguistTools)
 find_package(OpenSSL REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PULSEAUDIO REQUIRED libpulse)
@@ -75,7 +75,7 @@ qt_add_resources(librepods "resources"
 )
 
 target_link_libraries(librepods
-    PRIVATE Qt6::Quick Qt6::Widgets Qt6::Bluetooth Qt6::DBus OpenSSL::SSL OpenSSL::Crypto ${PULSEAUDIO_LIBRARIES}
+    PRIVATE Qt6::Quick Qt6::QuickControls2 Qt6::Widgets Qt6::Bluetooth Qt6::DBus OpenSSL::SSL OpenSSL::Crypto ${PULSEAUDIO_LIBRARIES}
 )
 
 qt_add_executable(librepods-ctl

--- a/linux/README.md
+++ b/linux/README.md
@@ -22,9 +22,10 @@ A native Linux application to control your AirPods, with support for:
    # For Arch Linux / EndeavourOS
    sudo pacman -S qt6-base qt6-connectivity qt6-multimedia-ffmpeg qt6-multimedia
 
-   # For Debian
+   # For Debian / Ubuntu
    sudo apt-get install qt6-base-dev qt6-declarative-dev qt6-connectivity-dev qt6-multimedia-dev \
-        qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
+        qml6-module-qtquick-controls qml6-module-qtquick-controls-fusion \
+        qml6-module-qtqml-workerscript qml6-module-qtquick-templates \
         qml6-module-qtquick-window qml6-module-qtquick-layouts
 
     # For Fedora

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -6,6 +6,7 @@
 #include <QQmlContext>
 #include <QBluetoothLocalDevice>
 #include <QBluetoothSocket>
+#include <QQuickStyle>
 #include <QQuickWindow>
 #include <QLoggingCategory>
 #include <QThread>
@@ -1041,6 +1042,18 @@ int main(int argc, char *argv[]) {
         if (QString(argv[i]) == "--hide")
             hideOnStart = true;
     }
+
+    // Pick a QtQuick.Controls style that ships a QML implementation.
+    // QQuickStyleSpec::resolve() reads QGuiApplicationPrivate::styleOverride
+    // (populated from QT_STYLE_OVERRIDE) before QT_QUICK_CONTROLS_STYLE, so on
+    // systems where the configured widget style has no Quick Controls
+    // counterpart (e.g. Kvantum on Stylix-themed Linux desktops) QML loading
+    // crashes with `module "<style>" is not installed`. Calling setStyle()
+    // unconditionally takes the highest-precedence slot, which both bypasses
+    // the QT_STYLE_OVERRIDE leak and lets QT_QUICK_CONTROLS_STYLE win even
+    // when QT_STYLE_OVERRIDE is also set.
+    const QString quickStyle = qEnvironmentVariable("QT_QUICK_CONTROLS_STYLE");
+    QQuickStyle::setStyle(quickStyle.isEmpty() ? QStringLiteral("Fusion") : quickStyle);
 
     QQmlApplicationEngine engine;
     qmlRegisterType<Battery>("me.kavishdevar.Battery", 1, 0, "Battery");


### PR DESCRIPTION
## Problem

`librepods` crashes at startup with `module "<style>" is not installed` whenever the session exports `QT_STYLE_OVERRIDE` pointing to a widgets-only style. This commonly happens when a user selects a `QStyle`-only theme via `qt6ct` / `qt5ct`, or when their session sets `QT_STYLE_OVERRIDE` directly (Kvantum being the most reported case, but the same crash class applies to any custom KDE style or third-party theme that ships a `QStyle` plugin without a Quick Controls counterpart).

Reproduction:

```
$ QT_STYLE_OVERRIDE=kvantum librepods
QQmlApplicationEngine failed to load component
qrc:/linux/Main.qml: module "kvantum" is not installed
```

The tray icon never appears and the QML window never opens.

## Root cause

In Qt6, `QQuickStyleSpec::resolve()` (qtdeclarative `src/quickcontrols/qquickstyle.cpp:127`) reads `QGuiApplicationPrivate::styleOverride` *before* `QT_QUICK_CONTROLS_STYLE`. `QApplication` populates that field from `QT_STYLE_OVERRIDE` (qtbase `src/widgets/kernel/qapplication.cpp:365`), and only clears it when `QStyleFactory::create()` *fails* (QTBUG-100563). Kvantum's `QStyle` plugin loads successfully, so the value sticks and gets reused as the Quick Controls style — but Kvantum ships no QML implementation, so the engine import fails. There is no automatic fallback in Qt6 for "the requested Quick style does not exist".

## Fix

Call `QQuickStyle::setStyle()` unconditionally before constructing `QQmlApplicationEngine`, just after the single-instance early return. `setStyle()` takes the highest-precedence slot in the resolver, which short-circuits the `QT_STYLE_OVERRIDE` leak. The env value is forwarded when `QT_QUICK_CONTROLS_STYLE` is set; otherwise `"Fusion"` is used. Choosing Fusion as the default keeps QPalette-driven theming working (qt6ct colour schemes still apply) and ships with every Qt6 distribution.

## Notes for maintainers

- `linux/main.cpp`: 1 include, 2 lines of logic, placed where QML actually loads (`trayApp->loadMainModule()` is called a few lines below).
- `linux/CMakeLists.txt`: adds `Qt6::QuickControls2` to `find_package` and to the `librepods` target. `librepods-ctl` is unaffected.
- `linux/README.md`: adds `qml6-module-qtquick-controls-fusion` to the Debian/Ubuntu apt line. Verified via packages.debian.org (trixie) and packages.ubuntu.com (noble) that `qml6-module-qtquick-controls` does not pull `-fusion` as a dependency or recommendation, so without this line a Debian/Ubuntu user would build cleanly and then fail at runtime with `module "QtQuick.Controls.Fusion" is not installed`. Arch (`qt6` / `qt6-declarative`) and Fedora (`qt6-qtdeclarative-devel`) bundle Fusion with declarative; no change there.

## Test plan

- [x] Build succeeds on Linux (Qt 6.11, CMake + Ninja).
- [x] Binary now imports `QQuickStyle::setStyle@Qt_6` (`nm -D`) and links against `libQt6QuickControls2.so.6` (`ldd`).
- [x] `QT_STYLE_OVERRIDE=kvantum librepods` launches cleanly, window opens, theming follows QPalette.
- [x] `QT_STYLE_OVERRIDE` unset: launches cleanly with Fusion default.
- [x] `QT_QUICK_CONTROLS_STYLE=Material librepods` still uses Material (user override path intact, even if `QT_STYLE_OVERRIDE` is also set — `setStyle()` outranks `styleOverride` in the resolver).
- [x] `librepods-ctl` unaffected (no QtQuick usage).

Closes #291, closes #280, closes #386.
