### PR TITLE
fix: add scrollable wrapper to device views

### DIFF
--- a/linux-rust/src/ui/airpods.rs
+++ b/linux-rust/src/ui/airpods.rs
@@ -520,7 +520,7 @@ pub fn airpods_view<'a>(
     ])
     .padding(20)
     .center_x(Length::Fill)
-    .height(Length::Fill)
+    .height(Length::Shrink)
 }
 
 fn run_async_in_thread<F>(fut: F)

--- a/linux-rust/src/ui/airpods.rs
+++ b/linux-rust/src/ui/airpods.rs
@@ -5,7 +5,7 @@ use iced::overlay::menu;
 use iced::widget::button::Style;
 use iced::widget::rule::FillMode;
 use iced::widget::{
-    Space, button, column, combo_box, container, row, rule, text, text_input, toggler,
+    Space, button, column, combo_box, container, row, rule, scrollable, text, text_input, toggler,
 };
 use iced::{Background, Border, Center, Color, Length, Padding, Theme};
 use log::error;
@@ -507,7 +507,7 @@ pub fn airpods_view<'a>(
         }
     }
 
-    container(column![
+    let content = container(column![
         rename_input,
         Space::new().height(Length::from(20)),
         listening_mode,
@@ -519,8 +519,10 @@ pub fn airpods_view<'a>(
         information_col
     ])
     .padding(20)
-    .center_x(Length::Fill)
-    .height(Length::Shrink)
+    .center_x(Length::Fill);
+
+    container(scrollable(content).height(Length::Fill))
+        .height(Length::Fill)
 }
 
 fn run_async_in_thread<F>(fut: F)

--- a/linux-rust/src/ui/nothing.rs
+++ b/linux-rust/src/ui/nothing.rs
@@ -5,7 +5,7 @@ use iced::border::Radius;
 use iced::overlay::menu;
 use iced::widget::combo_box;
 use iced::widget::text_input;
-use iced::widget::{Space, column, container, row, text};
+use iced::widget::{Space, column, container, row, scrollable, text};
 use iced::{Background, Border, Length, Theme};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -158,7 +158,7 @@ pub fn nothing_view<'a>(
         style
     });
 
-    container(column![
+    let content = container(column![
         noise_control_mode,
         Space::new().height(Length::from(20)),
         container(information_col)
@@ -174,8 +174,10 @@ pub fn nothing_view<'a>(
             .padding(20)
     ])
     .padding(20)
-    .center_x(Length::Fill)
-    .height(Length::Shrink)
+    .center_x(Length::Fill);
+
+    container(scrollable(content).height(Length::Fill))
+        .height(Length::Fill)
 }
 
 fn run_async_in_thread<F>(fut: F)

--- a/linux-rust/src/ui/nothing.rs
+++ b/linux-rust/src/ui/nothing.rs
@@ -175,7 +175,7 @@ pub fn nothing_view<'a>(
     ])
     .padding(20)
     .center_x(Length::Fill)
-    .height(Length::Fill)
+    .height(Length::Shrink)
 }
 
 fn run_async_in_thread<F>(fut: F)

--- a/linux-rust/src/ui/window.rs
+++ b/linux-rust/src/ui/window.rs
@@ -871,16 +871,12 @@ impl App {
                                             match state {
                                                 DeviceState::AirPods(state) => {
                                                     device_managers.get(id).and_then(|managers| {
-                                                        managers.get_aacp().map(|aacp_manager| {
-                                                            let view = airpods_view(
-                                                                id,
-                                                                &devices_list,
-                                                                state,
-                                                                aacp_manager.clone(),
-                                                            );
-                                                            container(scrollable(view).height(Length::Fill))
-                                                                .height(Length::Fill)
-                                                        })
+                                                        managers.get_aacp().map(|aacp_manager| airpods_view(
+                                                                    id,
+                                                                    &devices_list,
+                                                                    state,
+                                                                    aacp_manager.clone(),
+                                                                ))
                                                     })
                                                 }
                                                 _ => None,
@@ -897,9 +893,7 @@ impl App {
                                         if let Some(DeviceState::Nothing(state)) = device_state {
                                             if let Some(device_managers) = device_managers.get(id) {
                                                 if let Some(att_manager) = device_managers.get_att() {
-                                                let view = nothing_view(id, &devices_list, state, att_manager.clone());
-                                                container(scrollable(view).height(Length::Fill))
-                                                    .height(Length::Fill)
+                                                    nothing_view(id, &devices_list, state, att_manager.clone())
                                                 } else {
                                                     error!("No ATT manager found for Nothing device {}", id);
                                                     container(

--- a/linux-rust/src/ui/window.rs
+++ b/linux-rust/src/ui/window.rs
@@ -871,12 +871,16 @@ impl App {
                                             match state {
                                                 DeviceState::AirPods(state) => {
                                                     device_managers.get(id).and_then(|managers| {
-                                                        managers.get_aacp().map(|aacp_manager| airpods_view(
-                                                                    id,
-                                                                    &devices_list,
-                                                                    state,
-                                                                    aacp_manager.clone()
-                                                                ))
+                                                        managers.get_aacp().map(|aacp_manager| {
+                                                            let view = airpods_view(
+                                                                id,
+                                                                &devices_list,
+                                                                state,
+                                                                aacp_manager.clone(),
+                                                            );
+                                                            container(scrollable(view).height(Length::Fill))
+                                                                .height(Length::Fill)
+                                                        })
                                                     })
                                                 }
                                                 _ => None,
@@ -893,7 +897,9 @@ impl App {
                                         if let Some(DeviceState::Nothing(state)) = device_state {
                                             if let Some(device_managers) = device_managers.get(id) {
                                                 if let Some(att_manager) = device_managers.get_att() {
-                                                    nothing_view(id, &devices_list, state, att_manager.clone())
+                                                let view = nothing_view(id, &devices_list, state, att_manager.clone());
+                                                container(scrollable(view).height(Length::Fill))
+                                                    .height(Length::Fill)
                                                 } else {
                                                     error!("No ATT manager found for Nothing device {}", id);
                                                     container(


### PR DESCRIPTION
## what was the issue
so when you resize the window to be smaller, the content in the device view just gets clipped and theres no way to scroll to see the rest. this is because the outer container in `airpods_view` and `nothing_view` had `.height(Length::Fill)` which tells iced to just stretch the container to fill whatever space is available and clip anything that doesnt fit, instead of actually scrolling.

## update/information
as @kavishdevar wrote a review:
> It certainly works, but I don't think creating a container here just for scroll is ideal, at least not in `window`. The scroll should be a part of `airpods/nothing_view` and these fill the vertical space available.

as for this review i have made these changes:
- wrapped the content column in `scrollable()` inside `airpods_view` and `nothing_view` so the scroll is part of the view itself
- the views still fill the available space with `.height(Length::Fill)`
- reverted `window.rs` to call `airpods_view`/`nothing_view` directly without any scrollable or container wrapping
- added `scrollable` import to `airpods.rs` and `nothing.rs`

and my reply:
> yeah good point, moved the scrollable into `airpods_view` and `nothing_view` directly so window.rs just calls them without any wrapping. they still fill the available space with `height(Length::Fill)`

## testing (new)

compiled and tested on fedora linux 44 on kde plasma 6.6.4 with airpods 4 anc

[Screencast_20260512_134043.webm](https://github.com/user-attachments/assets/6790ceca-4c28-4e30-af7d-d02a72b6f144)


## what i changed (old)
- changed `.height(Length::Fill)` to `.height(Length::Shrink)` in `airpods.rs` (line 523) and `nothing.rs` (line 178) so the content sizes to its natural height instead of forcing itself to fill the pane
- wrapped both `airpods_view` and `nothing_view` calls in `window.rs` with `container(scrollable(view).height(Length::Fill))` so the views actually scroll when the window is too small to fit everything

the `scrollable` widget was already imported in `window.rs` so no new imports needed

## testing (old)
compiled and tested on fedora linux 43 on gnome with airpods 4 anc, resizing the window small now scrolls properly instead of clipping

the issue was mentioned by kavish on discord, i didn't even notice it until he mentioned it lol

## screencast (testing)
https://github.com/user-attachments/assets/ef318338-3329-48a0-847e-c730d17c9b4c