### PR TITLE
linux: add stem-press support (single/double/triple/long)

### DIFF
--- a/linux/airpods_packets.h
+++ b/linux/airpods_packets.h
@@ -152,6 +152,26 @@ namespace AirPodsPackets
         static const QByteArray SET_SPECIFIC_FEATURES = QByteArray::fromHex("040004004d00d700000000000000");
         static const QByteArray REQUEST_NOTIFICATIONS = QByteArray::fromHex("040004000f00ffffffffff");
         static const QByteArray AIRPODS_DISCONNECTED = QByteArray::fromHex("00010000");
+        // STEM_CONFIG (0x39) bitmask 0x0F — customize single|double|triple|long.
+        static const QByteArray STEM_CONFIG_ENABLE = QByteArray::fromHex("040004000900390f000000");
+    }
+
+    // Stem press (opcode 0x19): 04 00 04 00 19 00 [type] [bud]
+    namespace StemPress
+    {
+        enum class Type : quint8 { Single = 0x05, Double = 0x06, Triple = 0x07, Long = 0x08 };
+        enum class Bud  : quint8 { Left = 0x01, Right = 0x02 };
+        struct Event { Type type; Bud bud; };
+
+        static const QByteArray HEADER = QByteArray::fromHex("040004001900");
+
+        inline std::optional<Event> parseEvent(const QByteArray &data)
+        {
+            if (data.size() < 8 || !data.startsWith(HEADER)) return std::nullopt;
+            const quint8 t = static_cast<quint8>(data.at(6));
+            if (t < 0x05 || t > 0x08) return std::nullopt;
+            return Event{ static_cast<Type>(t), static_cast<Bud>(data.at(7)) };
+        }
     }
 
     // Phone Communication Packets

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -676,6 +676,7 @@ private slots:
                     writePacketToSocket(AirPodsPackets::Connection::REQUEST_NOTIFICATIONS, "Request notifications packet written: ");
                 }
             });
+            writePacketToSocket(AirPodsPackets::Connection::STEM_CONFIG_ENABLE, "Stem config enable packet written: ");
         }
         // Magic Cloud Keys Response
         else if (data.startsWith(AirPodsPackets::MagicPairing::MAGIC_CLOUD_KEYS_HEADER))
@@ -753,9 +754,28 @@ private slots:
                 LOG_INFO("One Bud ANC mode received: " << m_deviceInfo->oneBudANCMode());
             }
         }
+        else if (data.startsWith(AirPodsPackets::StemPress::HEADER))
+        {
+            if (auto ev = AirPodsPackets::StemPress::parseEvent(data))
+                handleStemPress(*ev);
+        }
         else
         {
             LOG_DEBUG("Unrecognized packet format: " << data.toHex());
+        }
+    }
+
+    void handleStemPress(const AirPodsPackets::StemPress::Event &ev)
+    {
+        using AirPodsPackets::StemPress::Type;
+        LOG_INFO("Stem press type=0x" << QString::number(static_cast<int>(ev.type), 16)
+                 << " bud=0x" << QString::number(static_cast<int>(ev.bud), 16));
+        switch (ev.type)
+        {
+            case Type::Double: mediaController->nextTrack();      break;
+            case Type::Triple: mediaController->previousTrack();  break;
+            case Type::Single:
+            case Type::Long:   mediaController->togglePlayPause(); break; // long = cycle ANC on Android; PlayPause fallback
         }
     }
 

--- a/linux/media/mediacontroller.cpp
+++ b/linux/media/mediacontroller.cpp
@@ -404,6 +404,26 @@ void MediaController::pause()
   }
 }
 
+// Invoke an MPRIS method on the first responsive org.mpris.MediaPlayer2.* service.
+static void invokeMprisMethod(const char *method)
+{
+  QDBusConnection bus = QDBusConnection::sessionBus();
+  for (const QString &service : bus.interface()->registeredServiceNames().value())
+  {
+    if (!service.startsWith("org.mpris.MediaPlayer2.")) continue;
+    QDBusInterface player(service, "/org/mpris/MediaPlayer2",
+                          "org.mpris.MediaPlayer2.Player", bus);
+    if (!player.isValid()) continue;
+    QDBusReply<void> reply = player.call(method);
+    if (reply.isValid()) { LOG_INFO("MPRIS " << method << " -> " << service); return; }
+  }
+  LOG_WARN("MPRIS " << method << ": no responsive player");
+}
+
+void MediaController::togglePlayPause() { invokeMprisMethod("PlayPause"); }
+void MediaController::nextTrack()       { invokeMprisMethod("Next"); }
+void MediaController::previousTrack()   { invokeMprisMethod("Previous"); }
+
 MediaController::~MediaController() {
 }
 

--- a/linux/media/mediacontroller.h
+++ b/linux/media/mediacontroller.h
@@ -47,6 +47,9 @@ public:
 
   void play();
   void pause();
+  void togglePlayPause();
+  void nextTrack();
+  void previousTrack();
   MediaState getCurrentMediaState() const;
 
 Q_SIGNALS:


### PR DESCRIPTION
# Linux: add stem-press support

Sends `STEM_CONFIG` (control `0x39`, bitmask `0x0F`) after `FEATURES_ACK`,
parses opcode `0x19` packets, dispatches via MPRIS.

| Press  | Action      |
| ------ | ----------- |
| Single | `PlayPause` |
| Double | `Next`      |
| Triple | `Previous`  |
| Long   | `PlayPause` *|

\* Android cycles noise control on long press; follow-up.

## Tested

AirPods 4 ANC (A3056) firmware `81.x`. Firmware `74.x` silently no-ops
`STEM_CONFIG`, so this is harmless on incapable firmware.

## Files

- `linux/airpods_packets.h` — `STEM_CONFIG_ENABLE` + `StemPress` namespace
- `linux/main.cpp` — send + parse + dispatch
- `linux/media/mediacontroller.{h,cpp}` — `togglePlayPause/nextTrack/previousTrack`

## Out of scope

- Per-action user mapping
- Long-press cycle noise control
- Model capability gating (packet is no-op on incapable firmware)
