### PR TITLE
linux-rust: fix config file creation

### DIFF
--- a/linux-rust/src/utils.rs
+++ b/linux-rust/src/utils.rs
@@ -37,12 +37,15 @@ pub fn get_app_settings_path() -> PathBuf {
     let old_path = PathBuf::from(&data_dir)
         .join("app_settings.json");
 
-    // migrate if needed
-    if old_path.exists() && !new_path.exists() {
+    // create new path if needed
+    if !new_path.exists() {
         if let Some(parent) = new_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
+    }
 
+    // migrate if needed
+    if old_path.exists() {
         if std::fs::copy(&old_path, &new_path).is_ok() {
             let _ = std::fs::remove_file(&old_path);
         }


### PR DESCRIPTION
When the config folder doesn't exist the application doesn't create it, this leads to a silenced panic on app_settings.json writes with std::fs::write, and settings are not saved.

This pull request adds a check to the get_app_settings_path function to create the config folder.