### PR TITLE
linux-rust: log device status in headless mode

### DIFF
--- a/linux-rust/src/headless.rs
+++ b/linux-rust/src/headless.rs
@@ -1,0 +1,88 @@
+use crate::bluetooth::aacp::{AACPEvent, BatteryComponent, BatteryInfo, BatteryStatus, ControlCommandIdentifiers};
+use crate::devices::enums::AirPodsNoiseControlMode;
+use crate::ui::messages::BluetoothUIMessage;
+use log::info;
+use std::collections::{HashMap, HashSet};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+fn battery_label(component: BatteryComponent) -> &'static str {
+    match component {
+        BatteryComponent::Headphone => "Headphones",
+        BatteryComponent::Left => "L",
+        BatteryComponent::Right => "R",
+        BatteryComponent::Case => "Case",
+    }
+}
+
+fn format_battery(info: &BatteryInfo) -> String {
+    match info.status {
+        BatteryStatus::Disconnected => format!("{}: disconnected", battery_label(info.component)),
+        BatteryStatus::Charging => format!("{}: {}% (charging)", battery_label(info.component), info.level),
+        BatteryStatus::NotCharging => format!("{}: {}%", battery_label(info.component), info.level),
+    }
+}
+
+#[derive(Default)]
+struct HeadlessStatus {
+    connected: HashSet<String>,
+    battery: HashMap<String, Vec<BatteryInfo>>,
+    listening_mode: HashMap<String, u8>,
+}
+
+/// Consumes `BluetoothUIMessage` in `--no-tray` mode (otherwise only the tray/GUI read this
+/// channel) and logs `info!` lines for connection, battery, and noise control mode changes,
+/// skipping events that don't change the last-known value.
+pub async fn run_headless_console(mut ui_rx: UnboundedReceiver<BluetoothUIMessage>) {
+    let mut status = HeadlessStatus::default();
+    while let Some(message) = ui_rx.recv().await {
+        match message {
+            BluetoothUIMessage::DeviceConnected(mac) => {
+                if status.connected.insert(mac.clone()) {
+                    info!("Connected: {}", mac);
+                }
+            }
+            BluetoothUIMessage::DeviceDisconnected(mac) => {
+                if status.connected.remove(&mac) {
+                    info!("Disconnected: {}", mac);
+                }
+                status.battery.remove(&mac);
+                status.listening_mode.remove(&mac);
+            }
+            BluetoothUIMessage::AACPUIEvent(mac, event) => match event {
+                AACPEvent::BatteryInfo(battery_info) => {
+                    let last = status.battery.entry(mac.clone()).or_default();
+                    for component_info in &battery_info {
+                        let changed = last
+                            .iter()
+                            .find(|b| b.component == component_info.component)
+                            .map(|b| b != component_info)
+                            .unwrap_or(true);
+                        if changed {
+                            info!("{} battery — {}", mac, format_battery(component_info));
+                        }
+                    }
+                    *last = battery_info;
+                }
+                AACPEvent::ControlCommand(status_update)
+                    if status_update.identifier == ControlCommandIdentifiers::ListeningMode =>
+                {
+                    let mode = status_update
+                        .value
+                        .first()
+                        .map(AirPodsNoiseControlMode::from_byte)
+                        .unwrap_or(AirPodsNoiseControlMode::Transparency);
+                    let mode_byte = mode.to_byte();
+                    let changed = status.listening_mode.get(&mac) != Some(&mode_byte);
+                    if changed {
+                        info!("{} noise control mode: {}", mac, mode);
+                        status.listening_mode.insert(mac, mode_byte);
+                    }
+                }
+                _ => {}
+            },
+            BluetoothUIMessage::OpenWindow
+            | BluetoothUIMessage::ATTNotification(_, _, _)
+            | BluetoothUIMessage::NoOp => {}
+        }
+    }
+}

--- a/linux-rust/src/main.rs
+++ b/linux-rust/src/main.rs
@@ -1,5 +1,6 @@
 mod bluetooth;
 mod devices;
+mod headless;
 mod media_controller;
 mod ui;
 mod utils;
@@ -8,6 +9,7 @@ use crate::bluetooth::discovery::{find_connected_airpods, find_other_managed_dev
 use crate::bluetooth::le::start_le_monitor;
 use crate::bluetooth::managers::DeviceManagers;
 use crate::devices::enums::DeviceData;
+use crate::headless::run_headless_console;
 use crate::ui::messages::BluetoothUIMessage;
 use crate::ui::tray::MyTray;
 use crate::utils::{get_app_settings_path, get_devices_path};
@@ -47,6 +49,24 @@ struct Args {
     version: bool
 }
 
+/// Default log filter: global level at `app_level`, with known-noisy external crates kept quiet
+/// unless the user already set `RUST_LOG` themselves, in which case that takes precedence.
+fn default_log_filter(debug: bool, le_debug: bool) -> String {
+    let app_level = if debug { "debug" } else { "info" };
+    let le_level = if le_debug { "debug" } else { "info" };
+    format!(
+        "{app_level},zbus=warn,winit=warn,tracing=warn,iced_wgpu=warn,wgpu_hal=warn,wgpu_core=warn,cosmic_text=warn,naga=warn,iced_winit=warn,librepods::bluetooth::le={le_level}"
+    )
+}
+
+fn init_logging(debug: bool, le_debug: bool) {
+    let env = env_logger::Env::default()
+        .filter_or("RUST_LOG", default_log_filter(debug, le_debug));
+    env_logger::Builder::from_env(env)
+        .format_timestamp_secs()
+        .init();
+}
+
 fn main() -> iced::Result {
     let args = Args::parse();
 
@@ -58,24 +78,11 @@ fn main() -> iced::Result {
         return Ok(());
     }
 
-    let log_level = if args.debug { "debug" } else { "info" };
     // let wayland_display = env::var("WAYLAND_DISPLAY").is_ok();
     // if wayland_display && env::var("WGPU_BACKEND").is_err() {
     //     unsafe { env::set_var("WGPU_BACKEND", "gl") };
     // }
-    if env::var("RUST_LOG").is_err() {
-        unsafe {
-            env::set_var(
-                "RUST_LOG",
-                log_level.to_owned()
-                    + &format!(
-                        ",zbus=warn,winit=warn,tracing=warn,iced_wgpu=warn,wgpu_hal=warn,wgpu_core=warn,cosmic_text=warn,naga=warn,iced_winit=warn,librepods::bluetooth::le={}",
-                        if args.le_debug { "debug" } else { "info" }
-                    ),
-            )
-        };
-    }
-    env_logger::init();
+    init_logging(args.debug, args.le_debug);
 
     let (ui_tx, ui_rx) = unbounded_channel::<BluetoothUIMessage>();
 
@@ -87,6 +94,7 @@ fn main() -> iced::Result {
         // Run headless without UI
         info!("Running in headless mode (no GUI)");
         let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.spawn(run_headless_console(ui_rx));
         rt.block_on(async_main(ui_tx, device_managers)).unwrap();
         Ok(())
     } else {


### PR DESCRIPTION
## Summary
- In `--no-tray` (headless) mode, the `BluetoothUIMessage` channel (connection, battery, noise control mode) was produced but never consumed — headless users had no visibility into device state.
- Adds `linux-rust/src/headless.rs`: a small console consumer that logs each field (connection, battery per component, noise control mode) only when it changes since the last observation, reusing the existing `AirPodsNoiseControlMode` decoding already used by the GUI.
- Cleans up logger initialization in `main.rs` into an explicit `env_logger::Builder` call instead of mutating `RUST_LOG` via an `unsafe` `env::set_var`, while still respecting a user-provided `RUST_LOG`.
- No new dependencies, no TUI/dashboard, no new IPC surface — output stays plain `log`-crate lines, consistent with the rest of the app.

## Test plan
- [x] `cargo build` / `cargo check` pass cleanly, no new warnings
- [x] Verified live with real AirPods Pro hardware in `--no-tray --debug`: connect, battery (incl. disconnected case), and noise control mode changes each logged exactly once, decoded to human-readable names
- [x] Verified GUI mode (without `--no-tray`) is unaffected — window/tray opens normally, no `headless` module output in that path