### PR TITLE
linux-rust: release AACP state before playback takeover

### DIFF
--- a/linux-rust/src/media_controller.rs
+++ b/linux-rust/src/media_controller.rs
@@ -138,11 +138,16 @@ impl MediaController {
             drop(state);
 
             if !was_playing && is_playing {
-                let aacp_state = aacp_manager.state.lock().await;
-                if !aacp_state
-                    .ear_detection_status
-                    .contains(&EarDetectionStatus::InEar)
-                {
+                let (bud_in_ear, connected_devices) = {
+                    let aacp_state = aacp_manager.state.lock().await;
+                    (
+                        aacp_state
+                            .ear_detection_status
+                            .contains(&EarDetectionStatus::InEar),
+                        aacp_state.connected_devices.clone(),
+                    )
+                };
+                if !bud_in_ear {
                     info!("Media playback started but buds not in ear, skipping takeover");
                     continue;
                 }
@@ -155,7 +160,6 @@ impl MediaController {
 
                 info!("already connected locally, hijacking connection by asking AirPods");
 
-                let connected_devices = aacp_state.connected_devices.clone();
                 for device in connected_devices {
                     if device.mac != local_mac {
                         if let Err(e) = aacp_manager


### PR DESCRIPTION
## Summary

- snapshot ear detection and connected-device state at the playback transition
- release the AACP state mutex before A2DP activation and takeover packet sends
- allow incoming events and queued control commands to proceed during profile recovery

## Validation

- cargo check --manifest-path linux-rust/Cargo.toml
- cargo nextest run --manifest-path linux-rust/Cargo.toml --no-tests pass

Fixes #684