### PR TITLE
android: make popup resources package-safe for FOSS builds

### DIFF
--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/IslandWindow.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/IslandWindow.kt
@@ -374,8 +374,12 @@ class IslandWindow(private val context: Context) {
         }
 
         val videoView = islandView.findViewById<VideoView>(R.id.island_video_view)
-        val videoUri = "android.resource://me.kavishdevar.librepods/${R.raw.island}".toUri()
+        val videoUri = "android.resource://${context.packageName}/${R.raw.island}".toUri()
         videoView.setAudioFocusRequest(AudioManager.AUDIOFOCUS_NONE)
+        videoView.setOnErrorListener { _, what, extra ->
+            e("IslandWindow", "Error playing island video: what=$what extra=$extra")
+            true
+        }
         videoView.setVideoURI(videoUri)
         videoView.setOnPreparedListener { mediaPlayer ->
             mediaPlayer.isLooping = true

--- a/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/PopupWindow.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/presentation/overlays/PopupWindow.kt
@@ -139,7 +139,11 @@ class PopupWindow(
 
                 val vid = mView.findViewById<VideoView>(R.id.video)
                 vid.setAudioFocusRequest(AudioManager.AUDIOFOCUS_NONE)
-                vid.setVideoPath("android.resource://me.kavishdevar.librepods/" + R.raw.connected)
+                vid.setOnErrorListener { _, what, extra ->
+                    Log.e("PopupWindow", "Error playing popup video: what=$what extra=$extra")
+                    true
+                }
+                vid.setVideoPath("android.resource://${context.packageName}/${R.raw.connected}")
                 vid.resolveAdjustedSize(vid.width, vid.height)
                 vid.start()
                 vid.setOnCompletionListener {

--- a/android/app/src/main/java/me/kavishdevar/librepods/utils/KotlinModule.kt
+++ b/android/app/src/main/java/me/kavishdevar/librepods/utils/KotlinModule.kt
@@ -98,7 +98,7 @@ class KotlinModule: XposedModule() {
                     }
 
                     val uri = iconUri.toUri()
-                    if (!uri.toString().startsWith("android.resource://me.kavishdevar.librepods")) {
+                    if (uri.authority != moduleApplicationInfo.packageName) {
                         return@intercept chain.proceed()
                     }
 


### PR DESCRIPTION
## Summary

Make popup and island overlay resources work with alternate application IDs, including the FOSS build.

## Root cause

The overlays constructed `android.resource` URIs with the Play package name (`me.kavishdevar.librepods`). In the FOSS build, the installed package is `me.kavishdevar.librepods.foss`, so `VideoView` failed to resolve the raw resource. Its default error dialog was then shown from the service context and crashed with `WindowManager.BadTokenException`.

## Changes

- Build popup and island video URIs from the runtime application package.
- Consume and log `VideoView` media errors so a media failure cannot open an invalid service-context dialog.
- Match Bluetooth icon resource authorities against the runtime module package in the Xposed hook.

## Verification

- `assembleFossRelease` succeeds from a clean `origin/main` base.
- The signed FOSS APK was installed on a Pixel 10 Pro running Android 17.
- The island-popup path was exercised after clearing logcat; it logged `Showing island window` and produced no fatal exception.

No existing issue or pull request was found for this exact alternate-application-ID/resource-URI failure. Issue #638 is adjacent but reports a non-responsive Play popup without crash or URI evidence.