### PR TITLE
feat(linux): add --no-tray-icon to hide the tray while keeping the GUI

### DIFF
--- a/linux-rust/src/main.rs
+++ b/linux-rust/src/main.rs
@@ -36,6 +36,13 @@ struct Args {
         help = "Disable system tray, useful if your environment doesn't support AppIndicator or StatusNotifier"
     )]
     no_tray: bool,
+    #[arg(
+        long,
+        help = "Hide the tray icon but keep the GUI running, so the window can \
+                still be opened. Unlike --no-tray, which disables the GUI \
+                entirely and leaves nothing able to open a window."
+    )]
+    no_tray_icon: bool,
     #[arg(long, help = "Start the application minimized to tray")]
     start_minimized: bool,
     #[arg(
@@ -126,7 +133,7 @@ async fn async_main(
         }
     }
 
-    let tray_handle = if args.no_tray {
+    let tray_handle = if args.no_tray || args.no_tray_icon {
         None
     } else {
         let tray = MyTray {


### PR DESCRIPTION
## Problem

`--no-tray` does more than its name suggests. It takes the headless path in `main.rs` and never starts the iced application:

```rust
if args.no_tray {
    // Run headless without UI
    info!("Running in headless mode (no GUI)");
```

So anything that needs the window becomes unreachable. A `BluetoothUIMessage::OpenWindow` is still accepted and sent, but there is no consumer on the other end, and the window silently never opens.

That behaviour is correct for a headless run. The gap is that it is the *only* way to remove the tray icon, so hiding the icon also costs the GUI.

This matters on desktops where a panel indicator already shows battery and listening mode. The tray icon is then redundant, but removing it today means losing the window with it.

## Change

`--no-tray-icon` skips only the tray registration and leaves the GUI running, so the window can still be opened.

`--no-tray` is untouched and keeps its current headless behaviour.

## Testing

Built and run on Ubuntu 26.04, GNOME Shell 50.1 (Wayland), with AirPods Pro 3.

With `--no-tray-icon --start-minimized`:

- no `Running in headless mode` line in the log — the GUI is up
- no `org.kde.StatusNotifierItem-*` name on the session bus — the icon is gone
- an `OpenWindow` message is both received and consumed, and the window opens

`--no-tray` was re-checked and still runs headless as before.